### PR TITLE
Add support for custom linting engines

### DIFF
--- a/init.js
+++ b/init.js
@@ -59,12 +59,22 @@ module.exports = {
               'no supported linter found',
               'no package.json found'
             ]
-            if (/linter.*not found/.test(err.message)) {
-              atom.notifications.addWarning(err.message, {
-                dismissable: true
-              })
+            if (suppressedErrorMessages.indexOf(err.message) !== -1) {
+              return []
             }
-            else if (suppressedErrorMessages.indexOf(err.message) === -1) {
+            var warnings = [
+              /incompatible linter/,
+              /linter.*not found/
+            ]
+            var isWarning = warnings.some(function (warning) {
+              if (warning.test(err.message)) {
+                atom.notifications.addWarning(err.message, {
+                  dismissable: true
+                })
+                return true
+              }
+            })
+            if (!isWarning) {
               atom.notifications.addError('Something bad happened', {
                 error: err,
                 detail: err.stack,

--- a/init.js
+++ b/init.js
@@ -6,6 +6,23 @@ var minimatch = require('minimatch')
 var path = require('path')
 
 module.exports = {
+  config: {
+    engine: {
+      title: 'Linting engine',
+      description: 'Which Standard Style engine to use. Choose "custom" to provide your own below. The default, "auto-detect", looks at your package.json to find a compatible linter from this list.',
+      type: 'string',
+      default: 'auto-detect',
+      enum: ['auto-detect', 'standard', 'semistandard', 'happiness', 'onelint', 'uber-standard', 'custom...'],
+      order: 1
+    },
+    customEngine: {
+      title: 'Custom linting engine',
+      description: 'Which "custom" engine (select above)  to use. Use the name of the package, e.g. "doublestandard" (without the quotes).',
+      type: 'string',
+      default: '',
+      order: 2
+    }
+  },
   deactivate: function () {
     cleanLinters()
   },
@@ -42,7 +59,12 @@ module.exports = {
               'no supported linter found',
               'no package.json found'
             ]
-            if (suppressedErrorMessages.indexOf(err.message) === -1) {
+            if (/linter.*not found/.test(err.message)) {
+              atom.notifications.addWarning(err.message, {
+                dismissable: true
+              })
+            }
+            else if (suppressedErrorMessages.indexOf(err.message) === -1) {
               atom.notifications.addError('Something bad happened', {
                 error: err,
                 detail: err.stack,

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -22,7 +22,18 @@ function firstPackageJson (filePath) {
   })
 }
 
-function readOptionsFromPackageJson (packageJsonPath) {
+function findOptionsByConfig (config, packageJsonPath) {
+  switch (config.engine) {
+    case 'auto-detect':
+      return autodetectOptions(packageJsonPath)
+    case 'custom...':
+      return readSpecificEngineOptions(config.customEngine, packageJsonPath)
+    default:
+      return readSpecificEngineOptions(config.engine, packageJsonPath)
+  }
+}
+
+function autodetectOptions (packageJsonPath) {
   return new Promise(function (resolve, reject) {
     fs.readFile(packageJsonPath, function (err, packageJson) {
       if (err) {
@@ -64,10 +75,47 @@ function readOptionsFromPackageJson (packageJsonPath) {
   })
 }
 
+function readSpecificEngineOptions (engine, packageJsonPath) {
+  return new Promise(function (resolve, reject) {
+    fs.readFile(packageJsonPath, function (err, packageJson) {
+      if (err) {
+        reject(err)
+      }
+      try {
+        packageJson = JSON.parse(packageJson)
+      } catch (e) {
+        e.message = 'Invalid package.json: ' + e.message
+        reject(e)
+      }
+
+      var dependencies = Object.keys(packageJson.dependencies || {})
+      var devDependencies = Object.keys(packageJson.devDependencies || {})
+
+      dependencies = dependencies.concat(devDependencies)
+
+      if (dependencies.indexOf(engine) === -1) {
+        return reject(new Error('linter "' + engine + '" not found'))
+      }
+
+      var pathToProject = path.dirname(packageJsonPath)
+
+      resolve({
+        linter: engine,
+        projectRoot: pathToProject,
+        pathToLinter: path.resolve(pathToProject, 'node_modules', engine),
+        options: packageJson[engine] || {}
+      })
+    })
+  })
+}
+
+
+
 module.exports = function findOptions (filePath) {
   return firstPackageJson(filePath)
     .then(function (packageJsonPath) {
-      return readOptionsFromPackageJson(packageJsonPath)
+      var config = atom.config.get('linter-js-standard-engine')
+      return findOptionsByConfig(config, packageJsonPath)
         .catch(function (err) {
           if (err.message === 'no supported linter found') {
             var nextPath = path.dirname(path.dirname(packageJsonPath))

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -32,20 +32,10 @@ function findOptionsByConfig (config, packageJsonPath) {
       return readSpecificEngineOptions(config.engine, packageJsonPath)
   }
 }
-
+!
 function autodetectOptions (packageJsonPath) {
-  return new Promise(function (resolve, reject) {
-    fs.readFile(packageJsonPath, function (err, packageJson) {
-      if (err) {
-        reject(err)
-      }
-      try {
-        packageJson = JSON.parse(packageJson)
-      } catch (e) {
-        e.message = 'Invalid package.json: ' + e.message
-        reject(e)
-      }
-
+  return readPackageJson(packageJsonPath)
+    .then(function (packageJson) {
       var supportedLinterKeys = Object.keys(packageJson).filter(function (key) {
         return supportedLinters.indexOf(key) !== -1
       })
@@ -59,52 +49,70 @@ function autodetectOptions (packageJsonPath) {
       }
 
       if (supportedLinterKeys.length < 1) {
-        return reject(new Error('no supported linter found'))
+        throw new Error('no supported linter found')
       }
 
       var linter = supportedLinterKeys[0]
       var pathToProject = path.dirname(packageJsonPath)
 
-      resolve({
+      return {
         linter: linter,
         projectRoot: pathToProject,
         pathToLinter: path.resolve(pathToProject, 'node_modules', linter),
         options: packageJson[linter] || {}
-      })
+      }
     })
-  })
 }
 
 function readSpecificEngineOptions (engine, packageJsonPath) {
+  return readPackageJson(packageJsonPath)
+    .then(function (packageJson) {
+      if (!hasDependency(engine, packageJson)) {
+        throw new Error('linter "' + engine + '" not found')
+      }
+
+      var pathToProject = path.dirname(packageJsonPath)
+      var pathToLinter = path.resolve(pathToProject, 'node_modules', engine)
+
+      return {
+        linter: engine,
+        projectRoot: pathToProject,
+        pathToLinter: pathToLinter,
+        options: packageJson[engine] || {}
+      }
+    })
+    .then(function (options) {
+      var pathToLinterPackageJson = path.resolve(options.pathToLinter, 'package.json')
+      return readPackageJson(pathToLinterPackageJson)
+        .then(function (linterPackageJson) {
+          if (!hasDependency('standard-engine', linterPackageJson)) {
+            throw new Error('incompatible linter "' + options.linter + '"')
+          }
+          return options
+        })
+    })
+}
+
+function hasDependency (dependency, packageJson) {
+  var packageDeps = Object.keys(packageJson.dependencies || {})
+  var packageDevDeps = Object.keys(packageJson.devDependencies || {})
+  packageDeps = packageDeps.concat(packageDevDeps)
+  return (packageDeps.indexOf(dependency) !== -1)
+}
+
+function readPackageJson (packageJsonPath) {
   return new Promise(function (resolve, reject) {
     fs.readFile(packageJsonPath, function (err, packageJson) {
       if (err) {
         reject(err)
+        return
       }
       try {
-        packageJson = JSON.parse(packageJson)
+        resolve(JSON.parse(packageJson))
       } catch (e) {
         e.message = 'Invalid package.json: ' + e.message
         reject(e)
       }
-
-      var dependencies = Object.keys(packageJson.dependencies || {})
-      var devDependencies = Object.keys(packageJson.devDependencies || {})
-
-      dependencies = dependencies.concat(devDependencies)
-
-      if (dependencies.indexOf(engine) === -1) {
-        return reject(new Error('linter "' + engine + '" not found'))
-      }
-
-      var pathToProject = path.dirname(packageJsonPath)
-
-      resolve({
-        linter: engine,
-        projectRoot: pathToProject,
-        pathToLinter: path.resolve(pathToProject, 'node_modules', engine),
-        options: packageJson[engine] || {}
-      })
     })
   })
 }

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -31,6 +31,8 @@ module.exports = function lint (filePath, fileContent) {
           }
         }))
       })
+    }).catch(function (err) {
+      throw new Error('incompatible linter')
     })
   }
 }

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -31,8 +31,6 @@ module.exports = function lint (filePath, fileContent) {
           }
         }))
       })
-    }).catch(function (err) {
-      throw new Error('incompatible linter')
     })
   }
 }

--- a/lib/supportedLinters.js
+++ b/lib/supportedLinters.js
@@ -1,7 +1,7 @@
 module.exports = [
   'standard',
   'semistandard',
-  'happiess',
+  'happiness',
   'onelint',
   'uber-standard'
 ]


### PR DESCRIPTION
This PR addresses #9 by adding two package settings, **Linting engine** and **Custom linting engine**.
Possible options for "linting engine" are:
- "auto-detect" (default, matches the current behaviour)
- explicitly selecting one of the `supportedLinters`
- "custom..."

The "custom linting engine" field is only used when the "custom..." engine is chosen.

![image](https://cloud.githubusercontent.com/assets/67802/13022910/8aab280e-d1e4-11e5-8538-335661b80a7d.png)

And if the custom engine doesn't have `standard-engine` as a dependency, the user gets a warning:

![image](https://cloud.githubusercontent.com/assets/67802/13023694/88bda8e4-d1eb-11e5-9f1b-352db8479904.png)
