### PR TITLE
Missing return statement when package.json is not found

### DIFF
--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -6,7 +6,7 @@ function firstPackageJson (filePath) {
   var dirName = path.dirname(filePath)
   return new Promise(function (resolve, reject) {
     if (filePath === dirName) {
-      reject(new Error('no package.json found'))
+      return reject(new Error('no package.json found'))
     }
     var packageJsonPath = path.resolve(dirName, 'package.json')
     fs.stat(packageJsonPath, function (err) {


### PR DESCRIPTION
This fixes the issue where Atom would start hogging the CPU if a package.json isn't present.

If a package.json is added and standard is installed, it starts linting properly.

If the package.json is removed, linting goes away, all without restarting Atom.
