### PR TITLE
Bump deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.nyc_output
 node_modules
 coverage

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   },
   "scripts": {
     "test": "mocha",
-    "coverage": "istanbul cover --include-all-sources _mocha"
+    "coverage": "nyc --all npm test"
   },
   "homepage": "https://github.com/gustavnikolaj/linter-js-standard-engine#readme",
   "devDependencies": {
     "debug": "2.2.0",
     "mocha": "^3.1.2",
+    "nyc": "^8.3.2",
     "standard": "^8.5.0",
     "unexpected": "^10.18.1",
     "unexpected-fs": "^2.5.2",
@@ -41,7 +42,6 @@
     }
   },
   "dependencies": {
-    "istanbul": "0.4.0",
     "lru-cache": "^4.0.1",
     "minimatch": "^3.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "homepage": "https://github.com/gustavnikolaj/linter-js-standard-engine#readme",
   "devDependencies": {
     "debug": "2.2.0",
-    "mocha": "2.3.3",
-    "standard": "5.3.1",
-    "unexpected": "10.1.0",
-    "unexpected-fs": "2.1.3",
-    "when": "3.7.4"
+    "mocha": "^3.1.2",
+    "standard": "^8.5.0",
+    "unexpected": "^10.18.1",
+    "unexpected-fs": "^2.5.2",
+    "when": "^3.7.7"
   },
   "standard": {
     "globals": [
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "istanbul": "0.4.0",
-    "lru-cache": "2.7.0",
-    "minimatch": "3.0.0"
+    "lru-cache": "^4.0.1",
+    "minimatch": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "engines": {
     "atom": ">=1.0.0"
   },
+  "files": [
+    "init.js",
+    "lib"
+  ],
   "scripts": {
     "test": "mocha",
     "coverage": "nyc --all npm test"


### PR DESCRIPTION
With the latest deps tests pass on Node.js v6 again.

Dependencies are now no longer pinned, was there a particular reason to pin them?

Swapped out `istanbul` for `nyc`, which is the new official CLI tool for Istanbul. Moved it to be a dev dependency as well.

Specified the `files` key since the tests were included in the package.
