### PR TITLE
Make linter configurable in the package.json itself

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.nyc_output
 node_modules
 coverage

--- a/init.js
+++ b/init.js
@@ -34,7 +34,7 @@ module.exports = {
             if (fileIsIgnored) {
               return [] // No errors
             }
-            return getLinter(options.pathToLinter)
+            return getLinter(options.pathToLinter, options.projectRoot)
               .then(lint(filePath, fileContent))
           })
           .catch(function (err) {

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var fs = require('fs')
+var resolveFrom = require('resolve-from')
 var supportedLinters = require('./supportedLinters')
 
 function firstPackageJson (filePath) {
@@ -35,7 +36,7 @@ function readOptionsFromPackageJson (packageJsonPath) {
         reject(e)
       }
 
-      var supportedLinterKeys = Object.keys(packageJson).filter(function (key) {
+      var linters = Object.keys(packageJson).filter(function (key) {
         return supportedLinters.indexOf(key) !== -1
       })
 
@@ -44,21 +45,32 @@ function readOptionsFromPackageJson (packageJsonPath) {
           .filter(function (key) {
             return supportedLinters.indexOf(key) !== -1
           })
-        supportedLinterKeys = supportedLinterKeys.concat(lintersFromDeps)
+        linters = linters.concat(lintersFromDeps)
       }
 
-      if (supportedLinterKeys.length < 1) {
+      if (packageJson['standard-engine']) {
+        linters.unshift(packageJson['standard-engine'])
+      }
+
+      if (linters.length < 1) {
         return reject(new Error('no supported linter found'))
       }
 
-      var linter = supportedLinterKeys[0]
+      var linter = linters[0]
       var pathToProject = path.dirname(packageJsonPath)
+
+      // Support scoped packages. Assume their `cmd` (and thus options key) is
+      // configured as the package name *without* the scope prefix.
+      var optionsKey = linter
+      if (optionsKey.indexOf('/') !== -1) {
+        optionsKey = optionsKey.split('/')[1]
+      }
 
       resolve({
         linter: linter,
         projectRoot: pathToProject,
-        pathToLinter: path.resolve(pathToProject, 'node_modules', linter),
-        options: packageJson[linter] || {}
+        pathToLinter: resolveFrom(pathToProject, linter),
+        options: packageJson[optionsKey] || {}
       })
     })
   })

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -58,6 +58,11 @@ function readOptionsFromPackageJson (packageJsonPath) {
 
       var linter = linters[0]
       var pathToProject = path.dirname(packageJsonPath)
+      var pathToLinter = resolveFrom(pathToProject, linter)
+
+      if (!pathToLinter) {
+        return reject(new Error('linter ' + linter + ' does not seem to be installed'))
+      }
 
       // Support scoped packages. Assume their `cmd` (and thus options key) is
       // configured as the package name *without* the scope prefix.
@@ -69,7 +74,7 @@ function readOptionsFromPackageJson (packageJsonPath) {
       resolve({
         linter: linter,
         projectRoot: pathToProject,
-        pathToLinter: resolveFrom(pathToProject, linter),
+        pathToLinter: pathToLinter,
         options: packageJson[optionsKey] || {}
       })
     })

--- a/lib/getLinter.js
+++ b/lib/getLinter.js
@@ -11,9 +11,9 @@ var linters = lruCache({
 
 var lintWorkerPath = path.resolve(__dirname, 'lintWorker.js')
 
-var createLinter = function (pathToLinter) {
+var createLinter = function (pathToLinter, projectRoot) {
   var child = fork(lintWorkerPath, [ pathToLinter ], {
-    cwd: pathToLinter.replace(/\/node_modules\/[a-z-]+$/, '')
+    cwd: projectRoot
   })
   var sequenceNumber = 0
   var pendingCallbacks = {}
@@ -46,13 +46,14 @@ var createLinter = function (pathToLinter) {
   }
 }
 
-module.exports = function getLinter (pathToLinter) {
+module.exports = function getLinter (pathToLinter, projectRoot) {
   return new Promise(function (resolve, reject) {
-    var linter = linters.get(pathToLinter)
+    var cacheKey = pathToLinter + '\n' + projectRoot
+    var linter = linters.get(cacheKey)
 
     if (!linter) {
-      linter = createLinter(pathToLinter)
-      linters.set(pathToLinter, linter)
+      linter = createLinter(pathToLinter, projectRoot)
+      linters.set(cacheKey, linter)
     }
 
     resolve(linter)

--- a/package.json
+++ b/package.json
@@ -14,12 +14,13 @@
   },
   "scripts": {
     "test": "mocha",
-    "coverage": "istanbul cover --include-all-sources _mocha"
+    "coverage": "nyc --all npm test"
   },
   "homepage": "https://github.com/gustavnikolaj/linter-js-standard-engine#readme",
   "devDependencies": {
     "debug": "2.2.0",
     "mocha": "^3.1.2",
+    "nyc": "^8.3.2",
     "standard": "^8.5.0",
     "unexpected": "^10.18.1",
     "unexpected-fs": "^2.5.2",
@@ -41,7 +42,6 @@
     }
   },
   "dependencies": {
-    "istanbul": "0.4.0",
     "lru-cache": "^4.0.1",
     "minimatch": "^3.0.3"
   }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "dependencies": {
     "lru-cache": "^4.0.1",
-    "minimatch": "^3.0.3"
+    "minimatch": "^3.0.3",
+    "resolve-from": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,11 +19,11 @@
   "homepage": "https://github.com/gustavnikolaj/linter-js-standard-engine#readme",
   "devDependencies": {
     "debug": "2.2.0",
-    "mocha": "2.3.3",
-    "standard": "5.3.1",
-    "unexpected": "10.1.0",
-    "unexpected-fs": "2.1.3",
-    "when": "3.7.4"
+    "mocha": "^3.1.2",
+    "standard": "^8.5.0",
+    "unexpected": "^10.18.1",
+    "unexpected-fs": "^2.5.2",
+    "when": "^3.7.7"
   },
   "standard": {
     "globals": [
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "istanbul": "0.4.0",
-    "lru-cache": "2.7.0",
-    "minimatch": "3.0.0"
+    "lru-cache": "^4.0.1",
+    "minimatch": "^3.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,10 @@
   "engines": {
     "atom": ">=1.0.0"
   },
+  "files": [
+    "init.js",
+    "lib"
+  ],
   "scripts": {
     "test": "mocha",
     "coverage": "nyc --all npm test"

--- a/test/lib/findOptions.spec.js
+++ b/test/lib/findOptions.spec.js
@@ -11,7 +11,7 @@ describe('lib/findOptions', function () {
     return expect(findOptions(__filename), 'to be fulfilled').then(function (options) {
       return expect(options, 'to satisfy', {
         linter: 'standard',
-        pathToLinter: /node_modules\/standard$/,
+        pathToLinter: require.resolve('standard'),
         options: {
           globals: [ 'atom' ]
         }
@@ -30,7 +30,7 @@ describe('lib/findOptions', function () {
       return expect(findOptions(fileName), 'to be fulfilled').then(function (options) {
         return expect(options, 'to satisfy', {
           linter: 'standard',
-          pathToLinter: /node_modules\/standard$/,
+          pathToLinter: require.resolve('standard'),
           options: {
             globals: [ 'atom' ]
           }


### PR DESCRIPTION
This includes changes from #13, so see the last two commits:

Support a `standard-engine` key in the `package.json` which maps to a
linter package. This will be the selected linter even if other linters
are detected.

Support scoped packages, assuming their `cmd` is the package name
without the scope prefix. Read options based on that unscoped package
name.

For example:

``` json
{
  "standard-engine": "@novemberborn/as-i-preach",
  "as-i-preach": {
    "ignore": "path-to-ignore.js"
  }
}
```

Use `resolve-from` to resolve the linter module. This ensures the linter
is indeed an installed package.

Ensure the worker is created with a CWD set to the `projectRoot`. Don't
replace parts of `pathToLinter`, since this won't work reliably with
scoped or globally installed linters.

---

The nice thing about this approach is `standard-engine` consumers can tell users to add this key to their `package.json` files and to use this Atom package. Then, magically, linting will work! IMO this means you could push this package as a more flexible replacement for `linter-js-standard`.

Using `resolve-from` lets us detect whether the linter is actually installed. Right now, if it isn't, the warning isn't surprised. Let me know if that should be changed.

`resolve-from` breaks the `should be able to find a devDependency` test since it skips the mocked file system. IMHO you could use actual fixtures instead and it'll will work. Or the `resolve-from` dependency will have to be mocked.

I find the test setup a bit daunting so I haven't tried to add tests for the new behavior yet. Please let me know if you like this approach!
