### PR TITLE
pass linterName to worker and require it directly

### DIFF
--- a/init.js
+++ b/init.js
@@ -34,7 +34,7 @@ module.exports = {
             if (fileIsIgnored) {
               return [] // No errors
             }
-            return getLinter(options.pathToLinter, options.projectRoot)
+            return getLinter(options.linter, options.projectRoot)
               .then(lint(filePath, fileContent))
           })
           .catch(function (err) {

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -1,6 +1,5 @@
 var path = require('path')
 var fs = require('fs')
-var resolveFrom = require('resolve-from')
 var supportedLinters = require('./supportedLinters')
 
 function firstPackageJson (filePath) {
@@ -58,11 +57,6 @@ function readOptionsFromPackageJson (packageJsonPath) {
 
       var linter = linters[0]
       var pathToProject = path.dirname(packageJsonPath)
-      var pathToLinter = resolveFrom(pathToProject, linter)
-
-      if (!pathToLinter) {
-        return reject(new Error('linter ' + linter + ' does not seem to be installed'))
-      }
 
       // Support scoped packages. Assume their `cmd` (and thus options key) is
       // configured as the package name *without* the scope prefix.
@@ -74,7 +68,6 @@ function readOptionsFromPackageJson (packageJsonPath) {
       resolve({
         linter: linter,
         projectRoot: pathToProject,
-        pathToLinter: pathToLinter,
         options: packageJson[optionsKey] || {}
       })
     })

--- a/lib/getLinter.js
+++ b/lib/getLinter.js
@@ -4,15 +4,15 @@ var lruCache = require('lru-cache')
 
 var linters = lruCache({
   max: 2,
-  dispose: function (pathToLinter, linter) {
+  dispose: function (cacheKey, linter) {
     linter.shutdown()
   }
 })
 
 var lintWorkerPath = path.resolve(__dirname, 'lintWorker.js')
 
-var createLinter = function (pathToLinter, projectRoot) {
-  var child = fork(lintWorkerPath, [ pathToLinter ], {
+var createLinter = function (linterName, projectRoot) {
+  var child = fork(lintWorkerPath, [ linterName ], {
     cwd: projectRoot
   })
   var sequenceNumber = 0
@@ -46,13 +46,13 @@ var createLinter = function (pathToLinter, projectRoot) {
   }
 }
 
-module.exports = function getLinter (pathToLinter, projectRoot) {
+module.exports = function getLinter (linterName, projectRoot) {
   return new Promise(function (resolve, reject) {
-    var cacheKey = pathToLinter + '\n' + projectRoot
+    var cacheKey = linterName + '\n' + projectRoot
     var linter = linters.get(cacheKey)
 
     if (!linter) {
-      linter = createLinter(pathToLinter, projectRoot)
+      linter = createLinter(linterName, projectRoot)
       linters.set(cacheKey, linter)
     }
 

--- a/lib/lintWorker.js
+++ b/lib/lintWorker.js
@@ -1,6 +1,5 @@
-var lintPath = process.argv.slice(2).pop()
-
-var linter = require(lintPath)
+var linterName = process.argv.slice(2).pop()
+var linter = require(linterName)
 
 process.on('message', function (data) {
   linter.lintText(data.source, function (err, result) {

--- a/lib/lintWorker.js
+++ b/lib/lintWorker.js
@@ -1,4 +1,4 @@
-var linterName = process.argv.slice(2).pop()
+var linterName = process.argv[2]
 var linter = require(linterName)
 
 process.on('message', function (data) {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
   },
   "dependencies": {
     "lru-cache": "^4.0.1",
-    "minimatch": "^3.0.3",
-    "resolve-from": "^2.0.0"
+    "minimatch": "^3.0.3"
   }
 }

--- a/test/lib/findOptions.spec.js
+++ b/test/lib/findOptions.spec.js
@@ -13,7 +13,6 @@ describe('lib/findOptions', function () {
     return expect(findOptions(__filename), 'to be fulfilled').then(function (options) {
       return expect(options, 'to satisfy', {
         linter: 'standard',
-        pathToLinter: require.resolve('standard'),
         options: {
           globals: [ 'atom' ]
         }
@@ -27,7 +26,6 @@ describe('lib/findOptions', function () {
         return expect(options, 'to equal', {
           projectRoot: fixturesPath('simpleSemiStandard'),
           linter: 'semistandard',
-          pathToLinter: fixturesPath('simpleSemiStandard/node_modules/semistandard/index.js'),
           options: {}
         })
       })
@@ -40,7 +38,6 @@ describe('lib/findOptions', function () {
         return expect(options, 'to equal', {
           projectRoot: fixturesPath('scopedLinter'),
           linter: '@novemberborn/as-i-preach',
-          pathToLinter: fixturesPath('scopedLinter/node_modules/@novemberborn/as-i-preach/index.js'),
           options: {}
         })
       })


### PR DESCRIPTION
The lintWorker is running in the project folder, so require works as expected, and any resolving tricks can be removed.

Fixes #18 
