### PR TITLE
stop calling findOptions recursively, and be stubborn when trying to require the linter.

### DIFF
--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -78,12 +78,5 @@ module.exports = function findOptions (filePath) {
   return firstPackageJson(filePath)
     .then(function (packageJsonPath) {
       return readOptionsFromPackageJson(packageJsonPath)
-        .catch(function (err) {
-          if (err.message === 'no supported linter found') {
-            var nextPath = path.dirname(path.dirname(packageJsonPath))
-            return findOptions(nextPath)
-          }
-          throw err
-        })
     })
 }

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -12,6 +12,9 @@ module.exports = function lint (filePath, fileContent) {
     return new Promise(function (resolve, reject) {
       linter.lintText(fileContent, function (err, output) {
         if (err) {
+          if (typeof err === 'string') {
+            err = new Error(err)
+          }
           return reject(err)
         }
 

--- a/lib/lintWorker.js
+++ b/lib/lintWorker.js
@@ -1,8 +1,25 @@
 var linterName = process.argv[2]
-var linter = require(linterName)
+
+var linterInstance = null
+function getLinter () {
+  if (linterInstance) {
+    return linterInstance
+  }
+
+  try {
+    linterInstance = require(linterName)
+    return linterInstance
+  } catch (e) {
+    return {
+      lintText: function (source, callback) {
+        callback('Could not load linter "' + linterName + '"')
+      }
+    }
+  }
+}
 
 process.on('message', function (data) {
-  linter.lintText(data.source, function (err, result) {
+  getLinter().lintText(data.source, function (err, result) {
     process.send({
       id: data.id,
       source: data.source,

--- a/test/fixtures/noStandardEngine/index.js
+++ b/test/fixtures/noStandardEngine/index.js
@@ -1,0 +1,1 @@
+module.exports = 'foo'

--- a/test/fixtures/noStandardEngine/package.json
+++ b/test/fixtures/noStandardEngine/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "module-with-no-standard-engine-linting"
+}

--- a/test/lib/findOptions.spec.js
+++ b/test/lib/findOptions.spec.js
@@ -39,4 +39,10 @@ describe('lib/findOptions', function () {
       })
     })
   })
+  it('should not select a linter for a project with no linter', function () {
+    var file = fixturesPath('noStandardEngine/index.js')
+    return expect(findOptions(file), 'to be rejected').then(function (msg) {
+      return expect(msg, 'to satisfy', 'no supported linter found')
+    })
+  })
 })

--- a/test/lib/findOptions.spec.js
+++ b/test/lib/findOptions.spec.js
@@ -20,27 +20,23 @@ describe('lib/findOptions', function () {
     })
   })
   it('should be able to find semistandard listed as devDependency', function () {
-    return expect(function () {
-      var file = fixturesPath('simpleSemiStandard/index.js')
-      return expect(findOptions(file), 'to be fulfilled').then(function (options) {
-        return expect(options, 'to equal', {
-          projectRoot: fixturesPath('simpleSemiStandard'),
-          linter: 'semistandard',
-          options: {}
-        })
+    var file = fixturesPath('simpleSemiStandard/index.js')
+    return expect(findOptions(file), 'to be fulfilled').then(function (options) {
+      return expect(options, 'to equal', {
+        projectRoot: fixturesPath('simpleSemiStandard'),
+        linter: 'semistandard',
+        options: {}
       })
-    }, 'not to error')
+    })
   })
   it('should be able to find @novemberborn/as-i-preach', function () {
-    return expect(function () {
-      var file = fixturesPath('scopedLinter/index.js')
-      return expect(findOptions(file), 'to be fulfilled').then(function (options) {
-        return expect(options, 'to equal', {
-          projectRoot: fixturesPath('scopedLinter'),
-          linter: '@novemberborn/as-i-preach',
-          options: {}
-        })
+    var file = fixturesPath('scopedLinter/index.js')
+    return expect(findOptions(file), 'to be fulfilled').then(function (options) {
+      return expect(options, 'to equal', {
+        projectRoot: fixturesPath('scopedLinter'),
+        linter: '@novemberborn/as-i-preach',
+        options: {}
       })
-    }, 'not to error')
+    })
   })
 })


### PR DESCRIPTION
extends #22 

This is a bit messy, but it follows up from changes caused by #18 and tries to improve the problems described in #19 

First, we stop at the first `package.json` file we find. Meaning that we won't use a parent modules linter configuration when linting a file in a nested module.

Try to require the linter in the lintWorker until it succeeds. Without this, the lintWorker would crash and cause annoying errors when trying to lint with a linter that hadn't been installed yet.
