### PR TITLE
report linter not found as lint result

### DIFF
--- a/lib/lintWorker.js
+++ b/lib/lintWorker.js
@@ -1,5 +1,9 @@
 var linterName = process.argv[2]
 
+function generateFakeLintResult (msg) {
+  return { results: [ { messages: [ { message: msg, fatal: true } ] } ] }
+}
+
 var linterInstance = null
 function getLinter () {
   if (linterInstance) {
@@ -12,7 +16,11 @@ function getLinter () {
   } catch (e) {
     return {
       lintText: function (source, callback) {
-        callback('Could not load linter "' + linterName + '"')
+        if (e.code === 'MODULE_NOT_FOUND') {
+          var message = 'Could not load linter "' + linterName + '"'
+          return callback(null, generateFakeLintResult(message))
+        }
+        callback(e.stack || e.message)
       }
     }
   }


### PR DESCRIPTION
Fixes #25 with linter warning reported when module is missing.

![could-not](https://cloud.githubusercontent.com/assets/1371503/19854354/d6f008d0-9f6e-11e6-9a6d-f69bc93106dc.png)
