### PR TITLE
Clear linter callbacks once invoked

### DIFF
--- a/lib/getLinter.js
+++ b/lib/getLinter.js
@@ -11,15 +11,21 @@ var linters = lruCache({
 
 var lintWorkerPath = path.resolve(__dirname, 'lintWorker.js')
 
+function getCallbackOnce (pending, id) {
+  const callback = pending.get(id)
+  pending.delete(id)
+  return callback
+}
+
 var createLinter = function (linterName, projectRoot) {
   var child = fork(lintWorkerPath, [ linterName ], {
     cwd: projectRoot
   })
   var sequenceNumber = 0
-  var pendingCallbacks = {}
+  var pendingCallbacks = new Map()
 
   child.on('message', function (data) {
-    var callback = pendingCallbacks[data.id]
+    var callback = getCallbackOnce(pendingCallbacks, data.id)
     if (callback) {
       if (data.err) {
         return callback(data.err)
@@ -33,7 +39,7 @@ var createLinter = function (linterName, projectRoot) {
     lintText: function (fileContent, cb) {
       sequenceNumber++
       var id = sequenceNumber
-      pendingCallbacks[id] = cb
+      pendingCallbacks.set(id, cb)
 
       child.send({
         id: id,


### PR DESCRIPTION
Hanging on to callbacks just creates memory leaks…