### PR TITLE
Fix linter resolution

### DIFF
--- a/lib/lintWorker.js
+++ b/lib/lintWorker.js
@@ -1,3 +1,5 @@
+var resolveCwd = require('resolve-cwd')
+
 var linterName = process.argv[2]
 
 function generateFakeLintResult (msg) {
@@ -10,20 +12,26 @@ function getLinter () {
     return linterInstance
   }
 
-  try {
-    linterInstance = require(linterName)
-    return linterInstance
-  } catch (e) {
-    return {
-      lintText: function (source, callback) {
-        if (e.code === 'MODULE_NOT_FOUND') {
-          var message = 'Could not load linter "' + linterName + '"'
-          return callback(null, generateFakeLintResult(message))
+  var linterPath = resolveCwd(linterName)
+  if (linterPath) {
+    try {
+      linterInstance = require(linterPath)
+    } catch (err) {
+      linterInstance = {
+        lintText (source, callback) {
+          callback(err)
         }
-        callback(e.stack || e.message)
+      }
+    }
+  } else {
+    linterInstance = {
+      lintText (source, callback) {
+        return callback(null, generateFakeLintResult('Could not load linter "' + linterName + '"'))
       }
     }
   }
+
+  return linterInstance
 }
 
 process.on('message', function (data) {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "dependencies": {
     "lru-cache": "^4.0.1",
     "minimatch": "^3.0.3",
-    "read-pkg-up": "^2.0.0"
+    "read-pkg-up": "^2.0.0",
+    "resolve-cwd": "^1.0.0"
   },
   "nyc": {
     "cache": true,

--- a/test/fixtures/localLinter/node_modules/my-linter/index.js
+++ b/test/fixtures/localLinter/node_modules/my-linter/index.js
@@ -1,0 +1,4 @@
+'use strict'
+exports.lintText = (source, cb) => {
+  cb(null, { hello: 'world' })
+}

--- a/test/fixtures/scopedLinter/node_modules/@novemberborn/as-i-preach/index.js
+++ b/test/fixtures/scopedLinter/node_modules/@novemberborn/as-i-preach/index.js
@@ -1,1 +1,0 @@
-module.exports = 'scoped linter'

--- a/test/fixtures/scopedLinter/node_modules/@novemberborn/as-i-preach/package.json
+++ b/test/fixtures/scopedLinter/node_modules/@novemberborn/as-i-preach/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "@novemberborn/as-i-preach",
-  "main": "index.js"
-}

--- a/test/fixtures/scopedLinter/package.json
+++ b/test/fixtures/scopedLinter/package.json
@@ -1,7 +1,7 @@
 {
   "name": "some-module",
-  "standard-engine": "@novemberborn/as-i-preach",
-  "devDependencies": {
-    "@novemberborn/as-i-preach": "1.0.0"
+  "standard-engine": "@my-scope/my-linter",
+  "my-linter": {
+    "hello": "world"
   }
 }

--- a/test/fixtures/simpleSemiStandard/node_modules/semistandard/index.js
+++ b/test/fixtures/simpleSemiStandard/node_modules/semistandard/index.js
@@ -1,1 +1,3 @@
-module.exports = 'foobar'
+exports.lintText = (source, cb) => {
+  cb(null, { results: [{ messages: [] }] })
+}

--- a/test/fixtures/standardEngineKey/index.js
+++ b/test/fixtures/standardEngineKey/index.js
@@ -1,0 +1,1 @@
+module.exports = 'foo!'

--- a/test/fixtures/standardEngineKey/package.json
+++ b/test/fixtures/standardEngineKey/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "some-module",
+  "devDependencies": {
+    "standard": "*"
+  },
+  "standard-engine": "my-linter"
+}

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -48,7 +48,7 @@ describe('linter-js-standard-engine', function () {
       path: filePath
     })
     return expect(lint(textEditor), 'to be fulfilled').then(function (data) {
-      return expect(data, 'to be a valid lint report')
+      return expect(data, 'to be empty')
     })
   })
   it('should clean linters when deactivated', () => {

--- a/test/lib/findOptions.spec.js
+++ b/test/lib/findOptions.spec.js
@@ -30,13 +30,25 @@ describe('lib/findOptions', function () {
       })
     })
   })
-  it('should be able to find @novemberborn/as-i-preach', function () {
+  it('should be able to find a linter from the standard-engine package.json key', function () {
+    var file = fixturesPath('standardEngineKey/index.js')
+    return expect(findOptions(file), 'to be fulfilled').then(function (options) {
+      return expect(options, 'to equal', {
+        projectRoot: fixturesPath('standardEngineKey'),
+        linter: 'my-linter',
+        options: {}
+      })
+    })
+  })
+  it('should read config for scoped linters', function () {
     var file = fixturesPath('scopedLinter/index.js')
     return expect(findOptions(file), 'to be fulfilled').then(function (options) {
       return expect(options, 'to equal', {
         projectRoot: fixturesPath('scopedLinter'),
-        linter: '@novemberborn/as-i-preach',
-        options: {}
+        linter: '@my-scope/my-linter',
+        options: {
+          hello: 'world'
+        }
       })
     })
   })

--- a/test/lib/lint.spec.js
+++ b/test/lib/lint.spec.js
@@ -77,6 +77,10 @@ describe('lib/lint.js', function () {
                   nodeType: 'Literal',
                   source: 'var foo = "bar"',
                   fix: { range: [10, 15], text: "'bar'" }
+                },
+                {
+                  fatal: true,
+                  message: 'Made up message to test fallback code paths'
                 }
               ],
               errorCount: 3,
@@ -108,6 +112,12 @@ describe('lib/lint.js', function () {
           text: 'Strings must use singlequote.',
           filePath: '/filePath',
           range: [ [ 0, 1 ], [ 0, 10 ] ]
+        },
+        {
+          type: 'Error',
+          text: 'Made up message to test fallback code paths',
+          filePath: '/filePath',
+          range: [ [ 0, 0 ], [ 0, 0 ] ]
         }
       ])
     })

--- a/test/lib/lintWorker.spec.js
+++ b/test/lib/lintWorker.spec.js
@@ -2,6 +2,7 @@
 
 const expect = require('unexpected')
 const childProcess = require('child_process')
+const path = require('path')
 
 const workerPath = require.resolve('../../lib/lintWorker')
 
@@ -35,7 +36,45 @@ describe('lib/lintWorker', () => {
     child.send({ id: 1, source: '' })
 
     return promise.then((message) => {
-      expect(message.err, 'to be', 'crash in linter loading')
+      expect(message.err, 'to have property', 'message', 'crash in linter loading')
+    })
+  })
+  it('should report missing linters as a linter message', () => {
+    const child = childProcess.fork(workerPath, ['non-existent-for-sure-or-so-we-hope'])
+    const promise = new Promise(resolve => {
+      child.on('message', m => resolve(m))
+    })
+
+    child.send({ id: 1, source: '' })
+
+    return promise.then((message) => {
+      expect(message, 'to satisfy', {
+        result: {
+          results: [
+            {
+              messages: [
+                {
+                  message: 'Could not load linter "non-existent-for-sure-or-so-we-hope"',
+                  fatal: true
+                }
+              ]
+            }
+          ]
+        }
+      })
+    })
+  })
+  it('should resolve linter from working directory', () => {
+    const cwd = path.resolve(__dirname, '..', 'fixtures', 'localLinter')
+    const child = childProcess.fork(workerPath, ['my-linter'], { cwd })
+    const promise = new Promise(resolve => {
+      child.on('message', m => resolve(m))
+    })
+
+    child.send({ id: 1, source: '' })
+
+    return promise.then((message) => {
+      expect(message.result, 'to have property', 'hello', 'world')
     })
   })
 })


### PR DESCRIPTION
Linters must be resolved from the project root, not the `lintWorker`
module. Fixes regression introduced in #22.

The previous behavior accidentally triggered code paths that did not
have explicit test coverage. Add new tests and fix tests and fixtures
that never quite worked but still passed.