### PR TITLE
ES2016 and refactor

### DIFF
--- a/init.js
+++ b/init.js
@@ -1,16 +1,16 @@
-var findOptions = require('./lib/findOptions')
-var getLinter = require('./lib/getLinter')
-var lint = require('./lib/lint')
-var cleanLinters = require('./lib/getLinter').cleanLinters
-var minimatch = require('minimatch')
-var path = require('path')
+const findOptions = require('./lib/findOptions')
+const getLinter = require('./lib/getLinter')
+const lint = require('./lib/lint')
+const cleanLinters = require('./lib/getLinter').cleanLinters
+const minimatch = require('minimatch')
+const path = require('path')
 
 function suppressError (err) {
   return [
     'no supported linter found',
     'no package.json found',
     /^Could not load linter "/
-  ].some(function (pattern) {
+  ].some(pattern => {
     if (typeof pattern === 'string') {
       return pattern === err.message
     }
@@ -22,29 +22,29 @@ function suppressError (err) {
 }
 
 module.exports = {
-  deactivate: function () {
+  deactivate () {
     cleanLinters()
   },
-  provideLinter: function () {
+  provideLinter () {
     return {
       name: 'lint',
       grammarScopes: ['source.js', 'source.js.jsx'],
       scope: 'file',
       lintOnFly: true,
-      lint: function (textEditor) {
-        var fileContent = textEditor.getText()
-        var filePath = textEditor.getPath()
-        var fileScope = textEditor.getGrammar().scopeName
+      lint (textEditor) {
+        const fileContent = textEditor.getText()
+        const filePath = textEditor.getPath()
+        const fileScope = textEditor.getGrammar().scopeName
 
-        if (this.grammarScopes.indexOf(fileScope) < 0) {
+        if (!this.grammarScopes.includes(fileScope)) {
           return Promise.resolve([])
         }
 
         return findOptions(filePath)
-          .then(function (options) {
-            var ignoreGlobs = options.options && options.options.ignore || []
-            var fileIsIgnored = ignoreGlobs.some(function (pattern) {
-              var relativePath = path.relative(options.projectRoot, filePath)
+          .then(options => {
+            const ignoreGlobs = options.options && options.options.ignore || []
+            const fileIsIgnored = ignoreGlobs.some(pattern => {
+              const relativePath = path.relative(options.projectRoot, filePath)
               return minimatch(relativePath, pattern)
             })
             if (fileIsIgnored) {
@@ -53,7 +53,7 @@ module.exports = {
             return getLinter(options.linter, options.projectRoot)
               .then(lint(filePath, fileContent))
           })
-          .catch(function (err) {
+          .catch(err => {
             if (!suppressError(err)) {
               atom.notifications.addError(err.message || 'Something bad happened', {
                 error: err,

--- a/init.js
+++ b/init.js
@@ -1,9 +1,9 @@
 const findOptions = require('./lib/findOptions')
 const getLinter = require('./lib/getLinter')
-const lint = require('./lib/lint')
+const perform = require('./lib/lint')
 const cleanLinters = require('./lib/getLinter').cleanLinters
 const minimatch = require('minimatch')
-const path = require('path')
+const { relative } = require('path')
 
 function suppressError (err) {
   return [
@@ -21,49 +21,44 @@ function suppressError (err) {
   })
 }
 
-module.exports = {
-  deactivate () {
-    cleanLinters()
-  },
-  provideLinter () {
-    return {
-      name: 'lint',
-      grammarScopes: ['source.js', 'source.js.jsx'],
-      scope: 'file',
-      lintOnFly: true,
-      lint (textEditor) {
-        const fileContent = textEditor.getText()
-        const filePath = textEditor.getPath()
-        const fileScope = textEditor.getGrammar().scopeName
+function lint (textEditor) {
+  const { scopeName } = textEditor.getGrammar()
+  if (!this.grammarScopes.includes(scopeName)) return Promise.resolve([])
 
-        if (!this.grammarScopes.includes(fileScope)) {
-          return Promise.resolve([])
-        }
+  // Get text at the time the linter was invoked.
+  const text = textEditor.getText()
+  const path = textEditor.getPath()
 
-        return findOptions(filePath)
-          .then(options => {
-            const ignoreGlobs = options.options && options.options.ignore || []
-            const fileIsIgnored = ignoreGlobs.some(pattern => {
-              const relativePath = path.relative(options.projectRoot, filePath)
-              return minimatch(relativePath, pattern)
-            })
-            if (fileIsIgnored) {
-              return [] // No errors
-            }
-            return getLinter(options.linter, options.projectRoot)
-              .then(lint(filePath, fileContent))
-          })
-          .catch(err => {
-            if (!suppressError(err)) {
-              atom.notifications.addError(err.message || 'Something bad happened', {
-                error: err,
-                detail: err.stack,
-                dismissable: true
-              })
-            }
-            return []
-          })
+  return findOptions(path)
+    .then(({ linterName, projectRoot, ignoreGlobs }) => {
+      const relativePath = relative(projectRoot, path)
+      const fileIsIgnored = ignoreGlobs.some(pattern => minimatch(relativePath, pattern))
+      if (fileIsIgnored) return [] // No errors
+
+      const linter = getLinter(linterName, projectRoot)
+      return perform(linter, path, text)
+    })
+    .catch(err => {
+      if (!suppressError(err)) {
+        atom.notifications.addError(err.message || 'Something bad happened', {
+          error: err,
+          detail: err.stack,
+          dismissable: true
+        })
       }
-    }
-  }
+
+      return []
+    })
 }
+
+exports.deactivate = () => {
+  cleanLinters()
+}
+
+exports.provideLinter = () => ({
+  name: 'standard-engine',
+  grammarScopes: ['source.js', 'source.js.jsx'],
+  scope: 'file',
+  lintOnFly: true,
+  lint
+})

--- a/init.js
+++ b/init.js
@@ -8,16 +8,9 @@ const { relative } = require('path')
 function suppressError (err) {
   return [
     'no supported linter found',
-    'no package.json found',
-    /^Could not load linter "/
+    'no package.json found'
   ].some(pattern => {
-    if (typeof pattern === 'string') {
-      return pattern === err.message
-    }
-    // istanbul ignore else
-    if (pattern instanceof RegExp) {
-      return pattern.test(err.message)
-    }
+    return pattern === err.message
   })
 }
 

--- a/init.js
+++ b/init.js
@@ -6,12 +6,7 @@ const minimatch = require('minimatch')
 const { relative } = require('path')
 
 function suppressError (err) {
-  return [
-    'no supported linter found',
-    'no package.json found'
-  ].some(pattern => {
-    return pattern === err.message
-  })
+  return err.name === 'MissingLinterError' || err.name === 'MissingPackageError'
 }
 
 function lint (textEditor) {

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -1,6 +1,6 @@
-var path = require('path')
-var readPkgUp = require('read-pkg-up')
-var supportedLinters = require('./supportedLinters')
+const path = require('path')
+const readPkgUp = require('read-pkg-up')
+const supportedLinters = require('./supportedLinters')
 
 function findOptions (filePath) {
   return readPkgUp({ cwd: path.dirname(filePath) }).then(result => {
@@ -9,13 +9,11 @@ function findOptions (filePath) {
       throw new Error('no package.json found')
     }
 
-    var linters = []
+    let linters = []
 
     if (packageJson.devDependencies) {
-      var lintersFromDeps = Object.keys(packageJson.devDependencies)
-        .filter(function (key) {
-          return supportedLinters.indexOf(key) !== -1
-        })
+      const lintersFromDeps = Object.keys(packageJson.devDependencies)
+        .filter(key => supportedLinters.includes(key))
       linters = linters.concat(lintersFromDeps)
     }
 
@@ -27,18 +25,18 @@ function findOptions (filePath) {
       throw new Error('no supported linter found')
     }
 
-    var linter = linters[0]
-    var pathToProject = path.dirname(result.path)
+    const linter = linters[0]
+    const pathToProject = path.dirname(result.path)
 
     // Support scoped packages. Assume their `cmd` (and thus options key) is
     // configured as the package name *without* the scope prefix.
-    var optionsKey = linter
-    if (optionsKey.indexOf('/') !== -1) {
+    let optionsKey = linter
+    if (optionsKey.includes('/')) {
       optionsKey = optionsKey.split('/')[1]
     }
 
     return {
-      linter: linter,
+      linter,
       projectRoot: pathToProject,
       options: packageJson[optionsKey] || {}
     }

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -1,11 +1,24 @@
 const { dirname } = require('path')
+const ExtendableError = require('es6-error')
 const readPkgUp = require('read-pkg-up')
 const supportedLinters = require('./supportedLinters')
+
+class MissingLinterError extends ExtendableError {
+  constructor (message = 'no supported linter found') {
+    super(message)
+  }
+}
+
+class MissingPackageError extends ExtendableError {
+  constructor (message = 'no package.json found') {
+    super(message)
+  }
+}
 
 function findOptions (file) {
   return readPkgUp({ cwd: dirname(file) })
     .then(({ path, pkg }) => {
-      if (!pkg) throw new Error('no package.json found')
+      if (!pkg) throw new MissingPackageError()
 
       let linters = []
       if (pkg.devDependencies) {
@@ -20,7 +33,7 @@ function findOptions (file) {
       }
 
       if (linters.length === 0) {
-        throw new Error('no supported linter found')
+        throw new MissingLinterError()
       }
 
       const linterName = linters[0]
@@ -43,4 +56,7 @@ function findOptions (file) {
     })
 }
 
-module.exports = findOptions
+exports = module.exports = findOptions
+
+exports.MissingLinterError = MissingLinterError
+exports.MissingPackageError = MissingPackageError

--- a/lib/findOptions.js
+++ b/lib/findOptions.js
@@ -1,46 +1,46 @@
-const path = require('path')
+const { dirname } = require('path')
 const readPkgUp = require('read-pkg-up')
 const supportedLinters = require('./supportedLinters')
 
-function findOptions (filePath) {
-  return readPkgUp({ cwd: path.dirname(filePath) }).then(result => {
-    const packageJson = result.pkg
-    if (!packageJson) {
-      throw new Error('no package.json found')
-    }
+function findOptions (file) {
+  return readPkgUp({ cwd: dirname(file) })
+    .then(({ path, pkg }) => {
+      if (!pkg) throw new Error('no package.json found')
 
-    let linters = []
+      let linters = []
+      if (pkg.devDependencies) {
+        for (const dep of Object.keys(pkg.devDependencies)) {
+          if (supportedLinters.includes(dep)) {
+            linters.push(dep)
+          }
+        }
+      }
+      if (pkg['standard-engine']) {
+        linters.unshift(pkg['standard-engine'])
+      }
 
-    if (packageJson.devDependencies) {
-      const lintersFromDeps = Object.keys(packageJson.devDependencies)
-        .filter(key => supportedLinters.includes(key))
-      linters = linters.concat(lintersFromDeps)
-    }
+      if (linters.length === 0) {
+        throw new Error('no supported linter found')
+      }
 
-    if (packageJson['standard-engine']) {
-      linters.unshift(packageJson['standard-engine'])
-    }
+      const linterName = linters[0]
 
-    if (linters.length < 1) {
-      throw new Error('no supported linter found')
-    }
+      // Support scoped packages. Assume their `cmd` (and thus options key) is
+      // configured as the package name *without* the scope prefix.
+      let optionsKey = linterName
+      if (optionsKey.includes('/')) {
+        optionsKey = optionsKey.split('/')[1]
+      }
 
-    const linter = linters[0]
-    const pathToProject = path.dirname(result.path)
+      const options = pkg[optionsKey] || {}
+      const { ignore: ignoreGlobs = [] } = options
 
-    // Support scoped packages. Assume their `cmd` (and thus options key) is
-    // configured as the package name *without* the scope prefix.
-    let optionsKey = linter
-    if (optionsKey.includes('/')) {
-      optionsKey = optionsKey.split('/')[1]
-    }
-
-    return {
-      linter,
-      projectRoot: pathToProject,
-      options: packageJson[optionsKey] || {}
-    }
-  })
+      return {
+        ignoreGlobs,
+        linterName,
+        projectRoot: dirname(path)
+      }
+    })
 }
 
 module.exports = findOptions

--- a/lib/getLinter.js
+++ b/lib/getLinter.js
@@ -1,52 +1,50 @@
 const { fork } = require('child_process')
-const path = require('path')
+const { resolve: resolvePath } = require('path')
 const lruCache = require('lru-cache')
 
 const linters = lruCache({
   max: 2,
-  dispose (cacheKey, linter) {
+  dispose (_, linter) {
     linter.shutdown()
   }
 })
 
-const lintWorkerPath = path.resolve(__dirname, 'lintWorker.js')
+const lintWorkerPath = resolvePath(__dirname, 'lintWorker.js')
 
-function getCallbackOnce (pending, id) {
-  const callback = pending.get(id)
+function getResolversOnce (pending, id) {
+  const resolvers = pending.get(id)
   pending.delete(id)
-  return callback
+  return resolvers
 }
 
 const createLinter = (linterName, projectRoot) => {
   const child = fork(lintWorkerPath, [ linterName ], {
     cwd: projectRoot
   })
-  let sequenceNumber = 0
-  const pendingCallbacks = new Map()
 
-  child.on('message', data => {
-    const callback = getCallbackOnce(pendingCallbacks, data.id)
-    if (callback) {
-      if (data.err) {
-        return callback(data.err)
+  let sequenceNumber = 0
+  const pendingResolvers = new Map()
+
+  child.on('message', ({ id, error, results }) => {
+    const resolvers = getResolversOnce(pendingResolvers, id)
+    if (resolvers) {
+      if (error) {
+        resolvers.reject(new Error(error.message))
       } else {
-        return callback(null, data.result)
+        resolvers.resolve(results)
       }
     }
   })
 
   return {
-    lintText (filePath, fileContent, cb) {
-      sequenceNumber++
-      const id = sequenceNumber
-      pendingCallbacks.set(id, cb)
-
-      child.send({
-        filename: filePath,
-        id: id,
-        source: fileContent
+    lintText (filename, source) {
+      const id = ++sequenceNumber
+      return new Promise((resolve, reject) => {
+        pendingResolvers.set(id, { resolve, reject })
+        child.send({ filename, id, source })
       })
     },
+
     shutdown () {
       // Shutdown is optimistic, but may be called when the linter is
       // intentionally removed from the cache. Ignore any errors thrown.
@@ -54,33 +52,30 @@ const createLinter = (linterName, projectRoot) => {
         child.disconnect()
       } catch (err) {}
     },
-    exited: new Promise(resolve => {
-      child.once('exit', resolve)
-    })
+
+    exited: new Promise(resolve => child.once('exit', resolve))
   }
 }
 
-module.exports = function getLinter (linterName, projectRoot) {
-  return new Promise((resolve, reject) => {
-    const cacheKey = linterName + '\n' + projectRoot
-    let linter = linters.get(cacheKey)
+function getLinter (linterName, projectRoot) {
+  const cacheKey = linterName + '\n' + projectRoot
+  if (linters.has(cacheKey)) return linters.get(cacheKey)
 
-    if (!linter) {
-      linter = createLinter(linterName, projectRoot)
-      linters.set(cacheKey, linter)
-      linter.exited.then(() => {
-        // A new linter may have been created in the meantime, make sure not to
-        // delete that one.
-        if (linters.peek(cacheKey) === linter) {
-          linters.del(cacheKey)
-        }
-      })
+  const linter = createLinter(linterName, projectRoot)
+  linters.set(cacheKey, linter)
+  linter.exited.then(() => {
+    // A new linter may have been created in the meantime, make sure not to
+    // delete that one.
+    if (linters.peek(cacheKey) === linter) {
+      linters.del(cacheKey)
     }
-
-    resolve(linter)
   })
+
+  return linter
 }
 
-module.exports.cleanLinters = () => {
+exports = module.exports = getLinter
+
+exports.cleanLinters = () => {
   linters.reset()
 }

--- a/lib/getLinter.js
+++ b/lib/getLinter.js
@@ -1,15 +1,15 @@
-var fork = require('child_process').fork
-var path = require('path')
-var lruCache = require('lru-cache')
+const { fork } = require('child_process')
+const path = require('path')
+const lruCache = require('lru-cache')
 
-var linters = lruCache({
+const linters = lruCache({
   max: 2,
-  dispose: function (cacheKey, linter) {
+  dispose (cacheKey, linter) {
     linter.shutdown()
   }
 })
 
-var lintWorkerPath = path.resolve(__dirname, 'lintWorker.js')
+const lintWorkerPath = path.resolve(__dirname, 'lintWorker.js')
 
 function getCallbackOnce (pending, id) {
   const callback = pending.get(id)
@@ -17,15 +17,15 @@ function getCallbackOnce (pending, id) {
   return callback
 }
 
-var createLinter = function (linterName, projectRoot) {
-  var child = fork(lintWorkerPath, [ linterName ], {
+const createLinter = (linterName, projectRoot) => {
+  const child = fork(lintWorkerPath, [ linterName ], {
     cwd: projectRoot
   })
-  var sequenceNumber = 0
-  var pendingCallbacks = new Map()
+  let sequenceNumber = 0
+  const pendingCallbacks = new Map()
 
-  child.on('message', function (data) {
-    var callback = getCallbackOnce(pendingCallbacks, data.id)
+  child.on('message', data => {
+    const callback = getCallbackOnce(pendingCallbacks, data.id)
     if (callback) {
       if (data.err) {
         return callback(data.err)
@@ -36,9 +36,9 @@ var createLinter = function (linterName, projectRoot) {
   })
 
   return {
-    lintText: function (filePath, fileContent, cb) {
+    lintText (filePath, fileContent, cb) {
       sequenceNumber++
-      var id = sequenceNumber
+      const id = sequenceNumber
       pendingCallbacks.set(id, cb)
 
       child.send({
@@ -47,7 +47,7 @@ var createLinter = function (linterName, projectRoot) {
         source: fileContent
       })
     },
-    shutdown: function () {
+    shutdown () {
       // Shutdown is optimistic, but may be called when the linter is
       // intentionally removed from the cache. Ignore any errors thrown.
       try {
@@ -61,9 +61,9 @@ var createLinter = function (linterName, projectRoot) {
 }
 
 module.exports = function getLinter (linterName, projectRoot) {
-  return new Promise(function (resolve, reject) {
-    var cacheKey = linterName + '\n' + projectRoot
-    var linter = linters.get(cacheKey)
+  return new Promise((resolve, reject) => {
+    const cacheKey = linterName + '\n' + projectRoot
+    let linter = linters.get(cacheKey)
 
     if (!linter) {
       linter = createLinter(linterName, projectRoot)
@@ -81,6 +81,6 @@ module.exports = function getLinter (linterName, projectRoot) {
   })
 }
 
-module.exports.cleanLinters = function () {
+module.exports.cleanLinters = () => {
   linters.reset()
 }

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -8,32 +8,28 @@ function getRange (line, col, src) {
 }
 
 module.exports = function lint (filePath, fileContent) {
-  return function (linter) {
-    return new Promise(function (resolve, reject) {
-      linter.lintText(filePath, fileContent, function (err, output) {
-        if (err) {
-          if (typeof err === 'string') {
-            err = new Error(err)
-          }
-          return reject(err)
+  return linter => new Promise((resolve, reject) => {
+    linter.lintText(filePath, fileContent, (err, output) => {
+      if (err) {
+        if (typeof err === 'string') {
+          err = new Error(err)
         }
+        return reject(err)
+      }
 
-        var results = output && output.results && output.results[0]
-        var messages = results && results.messages
+      const results = output && output.results && output.results[0]
+      const messages = results && results.messages
 
-        if (!Array.isArray(messages)) {
-          return reject(new Error('invalid lint report'))
-        }
+      if (!Array.isArray(messages)) {
+        return reject(new Error('invalid lint report'))
+      }
 
-        resolve(messages.map(function (msg) {
-          return {
-            type: msg.fatal ? 'Error' : 'Warning',
-            text: msg.message,
-            filePath: filePath,
-            range: getRange(msg.line, msg.column, msg.source)
-          }
-        }))
-      })
+      resolve(messages.map(msg => ({
+        type: msg.fatal ? 'Error' : 'Warning',
+        text: msg.message,
+        filePath,
+        range: getRange(msg.line, msg.column, msg.source)
+      })))
     })
-  }
+  })
 }

--- a/lib/lint.js
+++ b/lib/lint.js
@@ -1,35 +1,22 @@
-function getRange (line, col, src) {
-  line = typeof line !== 'undefined' ? parseInt((line - 1), 10) : 0
-  col = typeof col !== 'undefined' ? parseInt(col - 1, 10) : 0
-  src = src || ''
-  src = src.substring(0, col)
+function getRange (line = 1, column = 1, source = '') {
+  const line0 = line - 1
+  const column0 = column - 1
 
-  return [[line, col - src.trim().length], [line, col]]
+  const end = [line0, column0]
+  const start = [line0, column0 - source.slice(0, column0).trim().length]
+  return [start, end]
 }
 
-module.exports = function lint (filePath, fileContent) {
-  return linter => new Promise((resolve, reject) => {
-    linter.lintText(filePath, fileContent, (err, output) => {
-      if (err) {
-        if (typeof err === 'string') {
-          err = new Error(err)
-        }
-        return reject(err)
-      }
+module.exports = function lint (linter, filePath, fileContent) {
+  return linter.lintText(filePath, fileContent)
+    .then(([{ messages } = {}]) => {
+      if (!Array.isArray(messages)) throw new Error('invalid lint report')
 
-      const results = output && output.results && output.results[0]
-      const messages = results && results.messages
-
-      if (!Array.isArray(messages)) {
-        return reject(new Error('invalid lint report'))
-      }
-
-      resolve(messages.map(msg => ({
-        type: msg.fatal ? 'Error' : 'Warning',
-        text: msg.message,
+      return messages.map(({ fatal, message: text, line, column, source }) => ({
+        type: fatal ? 'Error' : 'Warning',
+        text,
         filePath,
-        range: getRange(msg.line, msg.column, msg.source)
-      })))
+        range: getRange(line, column, source)
+      }))
     })
-  })
 }

--- a/lib/lintWorker.js
+++ b/lib/lintWorker.js
@@ -1,18 +1,18 @@
-var resolveCwd = require('resolve-cwd')
+const resolveCwd = require('resolve-cwd')
 
-var linterName = process.argv[2]
+const linterName = process.argv[2]
 
 function generateFakeLintResult (msg) {
   return { results: [ { messages: [ { message: msg, fatal: true } ] } ] }
 }
 
-var linterInstance = null
+let linterInstance = null
 function getLinter () {
   if (linterInstance) {
     return linterInstance
   }
 
-  var linterPath = resolveCwd(linterName)
+  const linterPath = resolveCwd(linterName)
   if (linterPath) {
     try {
       linterInstance = require(linterPath)
@@ -26,7 +26,7 @@ function getLinter () {
   } else {
     linterInstance = {
       lintText (source, opts, callback) {
-        return callback(null, generateFakeLintResult('Could not load linter "' + linterName + '"'))
+        return callback(null, generateFakeLintResult(`Could not load linter "${linterName}"`))
       }
     }
   }
@@ -34,13 +34,13 @@ function getLinter () {
   return linterInstance
 }
 
-process.on('message', function (data) {
-  const cb = (err, result) => {
+process.on('message', data => {
+  const cb = (err, result = null) => {
     process.send({
       id: data.id,
       source: data.source,
-      result: result || null,
-      err: err
+      result,
+      err
     })
   }
 

--- a/lib/lintWorker.js
+++ b/lib/lintWorker.js
@@ -1,52 +1,62 @@
 const resolveCwd = require('resolve-cwd')
 
-const linterName = process.argv[2]
-
-function generateFakeLintResult (msg) {
-  return { results: [ { messages: [ { message: msg, fatal: true } ] } ] }
+// TODO: Better serialization, including stack traces
+function serializeError (err) {
+  return { message: err.message }
 }
 
-let linterInstance = null
-function getLinter () {
-  if (linterInstance) {
-    return linterInstance
-  }
-
+const linterName = process.argv[2]
+let linter, loadFailure
+{
   const linterPath = resolveCwd(linterName)
   if (linterPath) {
     try {
-      linterInstance = require(linterPath)
+      linter = require(linterPath)
     } catch (err) {
-      linterInstance = {
-        lintText (source, opts, callback) {
-          callback(err)
-        }
+      loadFailure = {
+        error: serializeError(err)
       }
     }
   } else {
-    linterInstance = {
-      lintText (source, opts, callback) {
-        return callback(null, generateFakeLintResult(`Could not load linter "${linterName}"`))
-      }
+    loadFailure = {
+      results: [
+        {
+          messages: [
+            {
+              message: `Could not load linter "${linterName}"`,
+              fatal: true
+            }
+          ]
+        }
+      ]
     }
   }
-
-  return linterInstance
 }
 
-process.on('message', data => {
-  const cb = (err, result = null) => {
-    process.send({
-      id: data.id,
-      source: data.source,
-      result,
-      err
-    })
+process.on('message', ({ filename, id, source }) => {
+  if (loadFailure) {
+    process.send(Object.assign({ id }, loadFailure))
+    return
   }
 
   try {
-    getLinter().lintText(data.source, { filename: data.filename }, cb)
+    linter.lintText(source, { filename }, (err, { results } = {}) => {
+      if (err) {
+        process.send({
+          error: serializeError(err),
+          id
+        })
+      } else {
+        process.send({
+          id,
+          results
+        })
+      }
+    })
   } catch (err) {
-    cb(err)
+    process.send({
+      error: serializeError(err),
+      id
+    })
   }
 })

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     }
   },
   "dependencies": {
+    "es6-error": "^4.0.1",
     "lru-cache": "^4.0.1",
     "minimatch": "^3.0.3",
     "read-pkg-up": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
     "proxyquire": "^1.7.10",
     "standard": "^8.5.0",
     "unexpected": "^10.18.1",
-    "unique-temp-dir": "^1.0.0",
-    "when": "^3.7.7"
+    "unique-temp-dir": "^1.0.0"
   },
   "standard": {
     "globals": [

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,4 +1,3 @@
-require('./util/promiseHelper')
 const textEditorFactory = require('./util/textEditorFactory')
 const linter = require('../init').provideLinter()
 const debugFactory = require('debug')

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,20 +1,20 @@
 require('./util/promiseHelper')
-var textEditorFactory = require('./util/textEditorFactory')
-var linter = require('../init').provideLinter()
-var debugFactory = require('debug')
+const textEditorFactory = require('./util/textEditorFactory')
+const linter = require('../init').provideLinter()
+const debugFactory = require('debug')
 
-var firstRun = debugFactory('first run')
-var secondRun = debugFactory('second run')
+const firstRun = debugFactory('first run')
+const secondRun = debugFactory('second run')
 
-var startTime = Date.now()
+const startTime = Date.now()
 
 firstRun('started')
 
-linter.lint(textEditorFactory('var foo = "bar"')).then(function (data) {
+linter.lint(textEditorFactory('var foo = "bar"')).then(data => {
   firstRun('done')
 
   secondRun('started')
-  linter.lint(textEditorFactory('var foo = "bar"')).then(function (data) {
+  linter.lint(textEditorFactory('var foo = "bar"')).then(data => {
     secondRun('done')
 
     console.log('\nTotal time spent:', Date.now() - startTime, 'ms')

--- a/test/fixtures/localLinter/node_modules/my-linter/index.js
+++ b/test/fixtures/localLinter/node_modules/my-linter/index.js
@@ -1,4 +1,4 @@
 'use strict'
 exports.lintText = (source, opts, cb) => {
-  cb(null, { hello: 'world' })
+  cb(null, { results: [{ hello: 'world' }] })
 }

--- a/test/fixtures/scopedLinter/package.json
+++ b/test/fixtures/scopedLinter/package.json
@@ -2,6 +2,6 @@
   "name": "some-module",
   "standard-engine": "@my-scope/my-linter",
   "my-linter": {
-    "hello": "world"
+    "ignore": ["world"]
   }
 }

--- a/test/fixtures/stubForWorker/crashOnLint.js
+++ b/test/fixtures/stubForWorker/crashOnLint.js
@@ -1,4 +1,3 @@
 exports.lintText = () => {
-  const err = { message: 'threw when linting' }
-  throw err
+  throw new Error('threw when linting')
 }

--- a/test/fixtures/stubForWorker/crashing.js
+++ b/test/fixtures/stubForWorker/crashing.js
@@ -1,2 +1,1 @@
-const err = { message: 'crash in linter loading' }
-throw err
+throw new Error('crash in linter loading')

--- a/test/fixtures/stubForWorker/errOnLint.js
+++ b/test/fixtures/stubForWorker/errOnLint.js
@@ -1,0 +1,3 @@
+exports.lintText = (source, opts, cb) => {
+  cb(new Error('err when linting'))
+}

--- a/test/fixtures/stubForWorker/index.js
+++ b/test/fixtures/stubForWorker/index.js
@@ -7,5 +7,5 @@ let count = 0
 
 exports.lintText = (source, opts, cb) => {
   count++
-  cb(null, { count })
+  cb(null, { results: [{ count }] })
 }

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -6,6 +6,7 @@ const proxyquire = require('proxyquire')
 const fs = require('fs')
 const path = require('path')
 const plugin = require('../init')
+const { MissingLinterError, MissingPackageError } = require('../lib/findOptions')
 const textEditorFactory = require('./util/textEditorFactory')
 const linter = plugin.provideLinter()
 const lint = linter.lint.bind(linter)
@@ -66,12 +67,9 @@ describe('linter-js-standard-engine', () => {
       }
     }).provideLinter()
 
-    for (const msg of [
-      'no supported linter found',
-      'no package.json found'
-    ]) {
-      it(`should suppress "${msg}" errors`, () => {
-        currentError = new Error(msg)
+    for (const ErrorClass of [MissingLinterError, MissingPackageError]) {
+      it(`should suppress "${ErrorClass.name}" errors`, () => {
+        currentError = new ErrorClass()
         return expect(linter.lint(textEditorFactory('')), 'to be fulfilled').then(data => expect(data, 'to be empty'))
       })
     }

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -1,39 +1,33 @@
 'use strict'
 /* global describe, it */
 
-var expect = require('unexpected').clone()
-var proxyquire = require('proxyquire')
-var fs = require('fs')
-var path = require('path')
-var plugin = require('../init')
-var textEditorFactory = require('./util/textEditorFactory')
-var linter = plugin.provideLinter()
-var lint = linter.lint.bind(linter)
+const expect = require('unexpected').clone()
+const proxyquire = require('proxyquire')
+const fs = require('fs')
+const path = require('path')
+const plugin = require('../init')
+const textEditorFactory = require('./util/textEditorFactory')
+const linter = plugin.provideLinter()
+const lint = linter.lint.bind(linter)
 
-expect.addAssertion('to be a valid lint report', function (expect, subject) {
-  return expect(subject, 'to have items satisfying', {
-    type: expect.it('to be a string').and('not to be empty'),
-    text: expect.it('to be a string').and('not to be empty'),
-    filePath: expect.it('to be a string').and('to match', /\.js$/),
-    range: expect.it('to have items satisfying', 'to have items satisfying', 'to be a number')
-  })
-})
+expect.addAssertion('to be a valid lint report', (expect, subject) => expect(subject, 'to have items satisfying', {
+  type: expect.it('to be a string').and('not to be empty'),
+  text: expect.it('to be a string').and('not to be empty'),
+  filePath: expect.it('to be a string').and('to match', /\.js$/),
+  range: expect.it('to have items satisfying', 'to have items satisfying', 'to be a number')
+}))
 
-describe('linter-js-standard-engine', function () {
-  it('should be able to lint a test file', function () {
-    var textEditor = textEditorFactory('var foo = "bar"')
-    return expect(lint(textEditor), 'to be fulfilled').then(function (data) {
-      return expect(data, 'to be a valid lint report')
-    })
+describe('linter-js-standard-engine', () => {
+  it('should be able to lint a test file', () => {
+    const textEditor = textEditorFactory('var foo = "bar"')
+    return expect(lint(textEditor), 'to be fulfilled').then(data => expect(data, 'to be a valid lint report'))
   })
-  it('should be able to lint a test file', function () {
-    var textEditor = textEditorFactory({
+  it('should be able to lint a test file', () => {
+    const textEditor = textEditorFactory({
       source: 'var foo = "bar"',
       path: path.resolve(__dirname, 'fixtures', 'faked', 'foo.js')
     })
-    return expect(lint(textEditor), 'to be fulfilled').then(function (data) {
-      return expect(data, 'to be empty')
-    })
+    return expect(lint(textEditor), 'to be fulfilled').then(data => expect(data, 'to be empty'))
   })
   it('should skip files with the wrong scope', () => {
     const textEditor = textEditorFactory({ source: '# markdown', scopeName: 'source.gfm' })
@@ -47,9 +41,7 @@ describe('linter-js-standard-engine', function () {
       source: fs.readFileSync(filePath),
       path: filePath
     })
-    return expect(lint(textEditor), 'to be fulfilled').then(function (data) {
-      return expect(data, 'to be empty')
-    })
+    return expect(lint(textEditor), 'to be fulfilled').then(data => expect(data, 'to be empty'))
   })
   it('should clean linters when deactivated', () => {
     let cleaned = false
@@ -81,16 +73,14 @@ describe('linter-js-standard-engine', function () {
     ]) {
       it(`should suppress "${msg}" errors`, () => {
         currentError = new Error(msg)
-        return expect(linter.lint(textEditorFactory('')), 'to be fulfilled').then(function (data) {
-          return expect(data, 'to be empty')
-        })
+        return expect(linter.lint(textEditorFactory('')), 'to be fulfilled').then(data => expect(data, 'to be empty'))
       })
     }
 
     it('should add errors that are not suppressed', () => {
       atom.notifications._errors = []
       currentError = new Error('do not suppress me')
-      return expect(linter.lint(textEditorFactory('')), 'to be fulfilled').then(function (data) {
+      return expect(linter.lint(textEditorFactory('')), 'to be fulfilled').then(data => {
         expect(data, 'to be empty')
 
         expect(atom.notifications._errors, 'to have length', 1)
@@ -111,7 +101,7 @@ describe('linter-js-standard-engine', function () {
     it('should add errors that are not suppressed with a default description', () => {
       atom.notifications._errors = []
       currentError = new Error('')
-      return expect(linter.lint(textEditorFactory('')), 'to be fulfilled').then(function (data) {
+      return expect(linter.lint(textEditorFactory('')), 'to be fulfilled').then(data => {
         expect(data, 'to be empty')
 
         expect(atom.notifications._errors, 'to have length', 1)

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -68,8 +68,7 @@ describe('linter-js-standard-engine', () => {
 
     for (const msg of [
       'no supported linter found',
-      'no package.json found',
-      'Could not load linter "foo"'
+      'no package.json found'
     ]) {
       it(`should suppress "${msg}" errors`, () => {
         currentError = new Error(msg)

--- a/test/init.spec.js
+++ b/test/init.spec.js
@@ -70,9 +70,7 @@ describe('linter-js-standard-engine', function () {
     let currentError
     const linter = proxyquire('../init', {
       './lib/lint' () {
-        return () => {
-          return Promise.reject(currentError)
-        }
+        return Promise.reject(currentError)
       }
     }).provideLinter()
 

--- a/test/lib/findOptions.spec.js
+++ b/test/lib/findOptions.spec.js
@@ -13,10 +13,8 @@ describe('lib/findOptions', function () {
   it('should be able to find options about this module', function () {
     return expect(findOptions(__filename), 'to be fulfilled').then(function (options) {
       return expect(options, 'to satisfy', {
-        linter: 'standard',
-        options: {
-          globals: [ 'atom' ]
-        }
+        linterName: 'standard',
+        ignoreGlobs: ['test/fixtures/faked/*.js']
       })
     })
   })
@@ -25,8 +23,8 @@ describe('lib/findOptions', function () {
     return expect(findOptions(file), 'to be fulfilled').then(function (options) {
       return expect(options, 'to equal', {
         projectRoot: fixturesPath('simpleSemiStandard'),
-        linter: 'semistandard',
-        options: {}
+        linterName: 'semistandard',
+        ignoreGlobs: []
       })
     })
   })
@@ -35,8 +33,8 @@ describe('lib/findOptions', function () {
     return expect(findOptions(file), 'to be fulfilled').then(function (options) {
       return expect(options, 'to equal', {
         projectRoot: fixturesPath('standardEngineKey'),
-        linter: 'my-linter',
-        options: {}
+        linterName: 'my-linter',
+        ignoreGlobs: []
       })
     })
   })
@@ -45,10 +43,8 @@ describe('lib/findOptions', function () {
     return expect(findOptions(file), 'to be fulfilled').then(function (options) {
       return expect(options, 'to equal', {
         projectRoot: fixturesPath('scopedLinter'),
-        linter: '@my-scope/my-linter',
-        options: {
-          hello: 'world'
-        }
+        linterName: '@my-scope/my-linter',
+        ignoreGlobs: ['world']
       })
     })
   })

--- a/test/lib/findOptions.spec.js
+++ b/test/lib/findOptions.spec.js
@@ -1,63 +1,51 @@
 /* global describe, it */
 
-var expect = require('unexpected')
-var uniqueTempDir = require('unique-temp-dir')
-var path = require('path')
-var findOptions = require('../../lib/findOptions')
+const expect = require('unexpected')
+const uniqueTempDir = require('unique-temp-dir')
+const path = require('path')
+const findOptions = require('../../lib/findOptions')
 
 function fixturesPath (relativePath) {
   return path.resolve(__dirname, '../fixtures', relativePath)
 }
 
-describe('lib/findOptions', function () {
-  it('should be able to find options about this module', function () {
-    return expect(findOptions(__filename), 'to be fulfilled').then(function (options) {
-      return expect(options, 'to satisfy', {
-        linterName: 'standard',
-        ignoreGlobs: ['test/fixtures/faked/*.js']
-      })
-    })
+describe('lib/findOptions', () => {
+  it('should be able to find options about this module', () => expect(findOptions(__filename), 'to be fulfilled').then(options => expect(options, 'to satisfy', {
+    linterName: 'standard',
+    ignoreGlobs: ['test/fixtures/faked/*.js']
+  })))
+  it('should be able to find semistandard listed as devDependency', () => {
+    const file = fixturesPath('simpleSemiStandard/index.js')
+    return expect(findOptions(file), 'to be fulfilled').then(options => expect(options, 'to equal', {
+      projectRoot: fixturesPath('simpleSemiStandard'),
+      linterName: 'semistandard',
+      ignoreGlobs: []
+    }))
   })
-  it('should be able to find semistandard listed as devDependency', function () {
-    var file = fixturesPath('simpleSemiStandard/index.js')
-    return expect(findOptions(file), 'to be fulfilled').then(function (options) {
-      return expect(options, 'to equal', {
-        projectRoot: fixturesPath('simpleSemiStandard'),
-        linterName: 'semistandard',
-        ignoreGlobs: []
-      })
-    })
+  it('should be able to find a linter from the standard-engine package.json key', () => {
+    const file = fixturesPath('standardEngineKey/index.js')
+    return expect(findOptions(file), 'to be fulfilled').then(options => expect(options, 'to equal', {
+      projectRoot: fixturesPath('standardEngineKey'),
+      linterName: 'my-linter',
+      ignoreGlobs: []
+    }))
   })
-  it('should be able to find a linter from the standard-engine package.json key', function () {
-    var file = fixturesPath('standardEngineKey/index.js')
-    return expect(findOptions(file), 'to be fulfilled').then(function (options) {
-      return expect(options, 'to equal', {
-        projectRoot: fixturesPath('standardEngineKey'),
-        linterName: 'my-linter',
-        ignoreGlobs: []
-      })
-    })
+  it('should read config for scoped linters', () => {
+    const file = fixturesPath('scopedLinter/index.js')
+    return expect(findOptions(file), 'to be fulfilled').then(options => expect(options, 'to equal', {
+      projectRoot: fixturesPath('scopedLinter'),
+      linterName: '@my-scope/my-linter',
+      ignoreGlobs: ['world']
+    }))
   })
-  it('should read config for scoped linters', function () {
-    var file = fixturesPath('scopedLinter/index.js')
-    return expect(findOptions(file), 'to be fulfilled').then(function (options) {
-      return expect(options, 'to equal', {
-        projectRoot: fixturesPath('scopedLinter'),
-        linterName: '@my-scope/my-linter',
-        ignoreGlobs: ['world']
-      })
-    })
-  })
-  it('should not select a linter for a project with no linter', function () {
-    var file = fixturesPath('noStandardEngine/index.js')
-    return expect(findOptions(file), 'to be rejected').then(function (msg) {
-      return expect(msg, 'to satisfy', 'no supported linter found')
-    })
+  it('should not select a linter for a project with no linter', () => {
+    const file = fixturesPath('noStandardEngine/index.js')
+    return expect(findOptions(file), 'to be rejected').then(msg => expect(msg, 'to satisfy', 'no supported linter found'))
   })
   it('should fail when package.json cannot be found', () => {
     // Outside of this directory, presumably without a package.json from there to the filesystem root.
-    var dir = uniqueTempDir({ create: true })
-    var file = path.join(dir, 'file.js')
+    const dir = uniqueTempDir({ create: true })
+    const file = path.join(dir, 'file.js')
     return expect(findOptions(file), 'to be rejected').then(msg => {
       return expect(msg, 'to satisfy', 'no package.json found')
     })

--- a/test/lib/lint.spec.js
+++ b/test/lib/lint.spec.js
@@ -1,99 +1,77 @@
 /* global describe, it */
 
 var expect = require('unexpected').clone()
-var lintFactory = require('../../lib/lint')
+var lint = require('../../lib/lint')
 
 describe('lib/lint.js', function () {
-  it('should return a function when called with path and content', function () {
-    return expect(lintFactory('/filePath', 'var foo = bar'), 'to be a function')
-  })
   it('should forward errors from the linters lintText() method', function () {
-    var lint = lintFactory('/filePath', 'var foo = bar')
     var linterMock = {
-      lintText: function (fileContent, opts, cb) {
-        return cb(new Error('MockError'))
+      lintText: function (fileContent, opts) {
+        return Promise.reject(new Error('MockError'))
       }
     }
-    return expect(lint(linterMock), 'to be rejected').then(function (err) {
+    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be rejected').then(function (err) {
       return expect(err, 'to have message', 'MockError')
     })
   })
-  it('should convert error strings from the linters lintText() method', () => {
-    const lint = lintFactory('/filePath', 'var foo = bar')
-    const linterMock = {
-      lintText: function (fileContent, opts, cb) {
-        return cb('error string')
-      }
-    }
-    return expect(lint(linterMock), 'to be rejected').then(function (err) {
-      return expect(err, 'to have message', 'error string')
-    })
-  })
   it('should fail upon receiving an invalid report from the linters lintText() method', () => {
-    const lint = lintFactory('/filePath', 'var foo = bar')
     const linterMock = {
       lintText: function (fileContent, opts, cb) {
-        return cb(null)
+        return Promise.resolve([])
       }
     }
-    return expect(lint(linterMock), 'to be rejected').then(function (err) {
+    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be rejected').then(function (err) {
       return expect(err, 'to have message', 'invalid lint report')
     })
   })
   it('should convert a eslint report to an atom report', function () {
-    var lint = lintFactory('/filePath', 'var foo = bar')
     var linterMock = {
       lintText: function (fileContent, opts, cb) {
-        var output = {
-          results: [
-            {
-              filePath: '<text>',
-              messages: [
-                {
-                  ruleId: 'eol-last',
-                  severity: 2,
-                  message: 'Newline required at end of file but not found.',
-                  line: 1,
-                  column: 2,
-                  nodeType: 'Program',
-                  source: 'var foo = "bar"',
-                  fix: { range: [15, 15], text: '\n' }
-                },
-                {
-                  ruleId: 'no-unused-vars',
-                  severity: 2,
-                  message: '"foo" is defined but never used',
-                  line: 1,
-                  column: 5,
-                  nodeType: 'Identifier',
-                  source: 'var foo = "bar"'
-                },
-                {
-                  ruleId: 'quotes',
-                  severity: 2,
-                  message: 'Strings must use singlequote.',
-                  line: 1,
-                  column: 11,
-                  nodeType: 'Literal',
-                  source: 'var foo = "bar"',
-                  fix: { range: [10, 15], text: "'bar'" }
-                },
-                {
-                  fatal: true,
-                  message: 'Made up message to test fallback code paths'
-                }
-              ],
-              errorCount: 3,
-              warningCount: 0
-            }
-          ],
-          errorCount: 3,
-          warningCount: 0
-        }
-        return cb(null, output)
+        return Promise.resolve([
+          {
+            filePath: '<text>',
+            messages: [
+              {
+                ruleId: 'eol-last',
+                severity: 2,
+                message: 'Newline required at end of file but not found.',
+                line: 1,
+                column: 2,
+                nodeType: 'Program',
+                source: 'var foo = "bar"',
+                fix: { range: [15, 15], text: '\n' }
+              },
+              {
+                ruleId: 'no-unused-vars',
+                severity: 2,
+                message: '"foo" is defined but never used',
+                line: 1,
+                column: 5,
+                nodeType: 'Identifier',
+                source: 'var foo = "bar"'
+              },
+              {
+                ruleId: 'quotes',
+                severity: 2,
+                message: 'Strings must use singlequote.',
+                line: 1,
+                column: 11,
+                nodeType: 'Literal',
+                source: 'var foo = "bar"',
+                fix: { range: [10, 15], text: "'bar'" }
+              },
+              {
+                fatal: true,
+                message: 'Made up message to test fallback code paths'
+              }
+            ],
+            errorCount: 3,
+            warningCount: 0
+          }
+        ])
       }
     }
-    return expect(lint(linterMock), 'to be fulfilled').then(function (report) {
+    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be fulfilled').then(function (report) {
       return expect(report, 'to equal', [
         {
           type: 'Warning',

--- a/test/lib/lint.spec.js
+++ b/test/lib/lint.spec.js
@@ -1,32 +1,28 @@
 /* global describe, it */
 
-var expect = require('unexpected').clone()
-var lint = require('../../lib/lint')
+const expect = require('unexpected').clone()
+const lint = require('../../lib/lint')
 
-describe('lib/lint.js', function () {
-  it('should forward errors from the linters lintText() method', function () {
-    var linterMock = {
-      lintText: function (fileContent, opts) {
+describe('lib/lint.js', () => {
+  it('should forward errors from the linters lintText() method', () => {
+    const linterMock = {
+      lintText (fileContent, opts) {
         return Promise.reject(new Error('MockError'))
       }
     }
-    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be rejected').then(function (err) {
-      return expect(err, 'to have message', 'MockError')
-    })
+    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be rejected').then(err => expect(err, 'to have message', 'MockError'))
   })
   it('should fail upon receiving an invalid report from the linters lintText() method', () => {
     const linterMock = {
-      lintText: function (fileContent, opts, cb) {
+      lintText (fileContent, opts, cb) {
         return Promise.resolve([])
       }
     }
-    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be rejected').then(function (err) {
-      return expect(err, 'to have message', 'invalid lint report')
-    })
+    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be rejected').then(err => expect(err, 'to have message', 'invalid lint report'))
   })
-  it('should convert a eslint report to an atom report', function () {
-    var linterMock = {
-      lintText: function (fileContent, opts, cb) {
+  it('should convert a eslint report to an atom report', () => {
+    const linterMock = {
+      lintText (fileContent, opts, cb) {
         return Promise.resolve([
           {
             filePath: '<text>',
@@ -71,33 +67,31 @@ describe('lib/lint.js', function () {
         ])
       }
     }
-    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be fulfilled').then(function (report) {
-      return expect(report, 'to equal', [
-        {
-          type: 'Warning',
-          text: 'Newline required at end of file but not found.',
-          filePath: '/filePath',
-          range: [ [ 0, 0 ], [ 0, 1 ] ]
-        },
-        {
-          type: 'Warning',
-          text: '"foo" is defined but never used',
-          filePath: '/filePath',
-          range: [ [ 0, 1 ], [ 0, 4 ] ]
-        },
-        {
-          type: 'Warning',
-          text: 'Strings must use singlequote.',
-          filePath: '/filePath',
-          range: [ [ 0, 1 ], [ 0, 10 ] ]
-        },
-        {
-          type: 'Error',
-          text: 'Made up message to test fallback code paths',
-          filePath: '/filePath',
-          range: [ [ 0, 0 ], [ 0, 0 ] ]
-        }
-      ])
-    })
+    return expect(lint(linterMock, '/filePath', 'var foo = bar'), 'to be fulfilled').then(report => expect(report, 'to equal', [
+      {
+        type: 'Warning',
+        text: 'Newline required at end of file but not found.',
+        filePath: '/filePath',
+        range: [ [ 0, 0 ], [ 0, 1 ] ]
+      },
+      {
+        type: 'Warning',
+        text: '"foo" is defined but never used',
+        filePath: '/filePath',
+        range: [ [ 0, 1 ], [ 0, 4 ] ]
+      },
+      {
+        type: 'Warning',
+        text: 'Strings must use singlequote.',
+        filePath: '/filePath',
+        range: [ [ 0, 1 ], [ 0, 10 ] ]
+      },
+      {
+        type: 'Error',
+        text: 'Made up message to test fallback code paths',
+        filePath: '/filePath',
+        range: [ [ 0, 0 ], [ 0, 0 ] ]
+      }
+    ]))
   })
 })

--- a/test/lib/lintWorker.spec.js
+++ b/test/lib/lintWorker.spec.js
@@ -23,8 +23,8 @@ describe('lib/lintWorker', () => {
     child.send({ id: 2, source: '' })
 
     return promise.then(() => {
-      expect(messages[0].result, 'to have property', 'count', 1)
-      expect(messages[1].result, 'to have property', 'count', 2)
+      expect(messages[0].results[0], 'to have property', 'count', 1)
+      expect(messages[1].results[0], 'to have property', 'count', 2)
     })
   })
   it('should report crashes in linter loading', () => {
@@ -36,7 +36,7 @@ describe('lib/lintWorker', () => {
     child.send({ id: 1, source: '' })
 
     return promise.then((message) => {
-      expect(message.err, 'to have property', 'message', 'crash in linter loading')
+      expect(message.error, 'to have property', 'message', 'crash in linter loading')
     })
   })
   it('should report missing linters as a linter message', () => {
@@ -49,18 +49,16 @@ describe('lib/lintWorker', () => {
 
     return promise.then((message) => {
       expect(message, 'to satisfy', {
-        result: {
-          results: [
-            {
-              messages: [
-                {
-                  message: 'Could not load linter "non-existent-for-sure-or-so-we-hope"',
-                  fatal: true
-                }
-              ]
-            }
-          ]
-        }
+        results: [
+          {
+            messages: [
+              {
+                message: 'Could not load linter "non-existent-for-sure-or-so-we-hope"',
+                fatal: true
+              }
+            ]
+          }
+        ]
       })
     })
   })
@@ -74,7 +72,7 @@ describe('lib/lintWorker', () => {
     child.send({ id: 1, source: '' })
 
     return promise.then((message) => {
-      expect(message.result, 'to have property', 'hello', 'world')
+      expect(message.results[0], 'to have property', 'hello', 'world')
     })
   })
   it('should report crashes when linting', () => {
@@ -86,7 +84,19 @@ describe('lib/lintWorker', () => {
     child.send({ id: 1, source: '' })
 
     return promise.then((message) => {
-      expect(message.err, 'to have property', 'message', 'threw when linting')
+      expect(message.error, 'to have property', 'message', 'threw when linting')
+    })
+  })
+  it('should report errors when linting', () => {
+    const child = childProcess.fork(workerPath, [require.resolve('../fixtures/stubForWorker/errOnLint')])
+    const promise = new Promise(resolve => {
+      child.on('message', m => resolve(m))
+    })
+
+    child.send({ id: 1, source: '' })
+
+    return promise.then((message) => {
+      expect(message.error, 'to have property', 'message', 'err when linting')
     })
   })
 })

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,5 +1,4 @@
 --recursive
 --reporter spec
---require test/util/promiseHelper
 --require test/util/atomHelper
 test/**/*.spec.js

--- a/test/util/atomHelper.js
+++ b/test/util/atomHelper.js
@@ -3,7 +3,7 @@ if (typeof global.atom === 'undefined') {
     notifications: {
       _errors: [],
 
-      addError: function (desc, obj) {
+      addError (desc, obj) {
         const promise = new Promise((resolve, reject) => {
           // Reject using setImmediate, allowing tests to silence the error
           // before it's reported has an unhandled rejection.

--- a/test/util/promiseHelper.js
+++ b/test/util/promiseHelper.js
@@ -1,3 +1,0 @@
-if (typeof global.Promise === 'undefined') {
-  global.Promise = require('when').Promise
-}

--- a/test/util/textEditorFactory.js
+++ b/test/util/textEditorFactory.js
@@ -1,20 +1,19 @@
-var path = require('path')
+const path = require('path')
 
-module.exports = function textEditorFactory (input) {
-  input = input || {}
+module.exports = function textEditorFactory (input = {}) {
   if (typeof input === 'string') {
     input = {
       source: input
     }
   }
   return {
-    getText: function () {
+    getText () {
       return input.source || ''
     },
-    getPath: function () {
+    getPath () {
       return input.path || path.resolve(__dirname, 'foo.js') // standard devDep will be found
     },
-    getGrammar: function () {
+    getGrammar () {
       return {
         scopeName: input.scopeName || 'source.js'
       }


### PR DESCRIPTION
First commit upgrades the source to ES2016. I've left tests alone for now but will do that as a follow-up.

Second commit refactors the implementation:

* Change name, when providing linter
* Resolve only ignoreGlobs from the package.json options
* Rename linter key in options to linterName
* Simply pass linter object to lint(), so it doesn't need to return a
function
* Make getting a linter synchronous
* Implement naive error serialization (assumes errors have a message)
* In the main process, change the linter's lintText() to return a
promise
* Reject the aforementioned promise with a proper error if the worker
responds with a serialized error object
* Simplify worker implementation and response object
* Attempt to simplify range conversion