### PR TITLE
Require opt-in before linting a new project

### DIFF
--- a/lib/linting.js
+++ b/lib/linting.js
@@ -5,6 +5,7 @@ const minimatch = require('minimatch')
 
 const { GRAMMAR_SCOPES } = require('./constants')
 const findOptions = require('./findOptions')
+const { checkPermission } = require('./optInManager')
 const { getWorker } = require('./workerManagement')
 
 function getRange (line = 1, column = 1, source = '') {
@@ -40,11 +41,16 @@ function getReport (textEditor, fix) {
       const fileIsIgnored = ignoreGlobs.some(pattern => minimatch(relativePath, pattern))
       if (fileIsIgnored) return null
 
-      const worker = getWorker(linterName, projectRoot)
-      return worker.lint(filePath, fileContent, fix)
-        .then(([{ messages, output } = {}]) => {
-          if (!Array.isArray(messages)) throw new InvalidReportError()
-          return { filePath, messages, output }
+      return checkPermission(linterName, projectRoot)
+        .then(allowed => {
+          if (!allowed) return null
+
+          const worker = getWorker(linterName, projectRoot)
+          return worker.lint(filePath, fileContent, fix)
+            .then(([{ messages, output } = {}]) => {
+              if (!Array.isArray(messages)) throw new InvalidReportError()
+              return { filePath, messages, output }
+            })
         })
     })
 }

--- a/lib/optInManager.js
+++ b/lib/optInManager.js
@@ -1,0 +1,114 @@
+const { createHash, randomBytes } = require('crypto')
+const caches = require('./caches')
+
+const NONE = 1
+exports.NONE = NONE
+
+const SOME = 2
+exports.SOME = SOME
+
+const ALL = 3
+exports.ALL = ALL
+
+class State {
+  constructor (allowAll, { seed, allowed = [] } = {}) {
+    this.allowAll = allowAll && Promise.resolve(true)
+    this.seed = seed ? Buffer.from(seed, 'base64') : randomBytes(16)
+    this.allowed = new Set(allowed)
+
+    this.cache = caches.add(new Map())
+  }
+
+  dispose () {
+    this.cache.clear()
+  }
+}
+
+let state
+let subscription
+
+function activate (serialized) {
+  state = new State(atom.config.get('linter-js-standard-engine.enabledProjects') === ALL, serialized)
+
+  subscription = atom.config.onDidChange('linter-js-standard-engine.enabledProjects', ({newValue}) => {
+    state.dispose()
+
+    state = new State(newValue === ALL)
+    if (newValue === NONE) {
+      atom.config.set('linter-js-standard-engine.enabledProjects', SOME)
+    }
+  })
+}
+exports.activate = activate
+
+function deactivate () {
+  subscription.dispose()
+}
+exports.deactivate = deactivate
+
+function serialize () {
+  return {
+    seed: state.seed.toString('base64'),
+    allowed: Array.from(state.allowed)
+  }
+}
+exports.serialize = serialize
+
+function checkPermission (linterName, projectRoot) {
+  if (state.allowAll) return state.allowAll
+
+  const {cache} = state
+  const cacheKey = `${linterName}\n${projectRoot}`
+  if (cache.has(cacheKey)) return cache.get(cacheKey)
+
+  // Hash the cache key, no need to store project paths and linter names in the serialized state.
+  const stateKey = createHash('sha256')
+    .update(state.seed)
+    .update(cacheKey)
+    .digest('base64')
+
+  if (state.allowed.has(stateKey)) {
+    const promise = Promise.resolve(true)
+    cache.set(cacheKey, promise)
+    return promise
+  }
+
+  const promise = new Promise(resolve => {
+    let dismissedViaButton = false
+
+    const notification = atom.notifications.addInfo('Enable linter?', {
+      buttons: [
+        {
+          text: 'This project only',
+          onDidClick () {
+            state.allowed.add(stateKey)
+            resolve(true)
+            dismissedViaButton = true
+            notification.dismiss()
+          }
+        },
+        {
+          text: 'Run any linter for this and all future projects',
+          onDidClick () {
+            atom.config.set('linter-js-standard-engine.enabledProjects', ALL)
+            resolve(true)
+            dismissedViaButton = true
+            notification.dismiss()
+          }
+        }
+      ],
+      description: `Do you want to run \`${linterName}\`, as provided by \`${projectRoot}\`?`,
+      dismissable: true
+    })
+
+    notification.onDidDismiss(() => {
+      if (dismissedViaButton) return
+
+      cache.delete(cacheKey)
+      resolve(false)
+    })
+  })
+  cache.set(cacheKey, promise)
+  return promise
+}
+exports.checkPermission = checkPermission

--- a/lib/register.js
+++ b/lib/register.js
@@ -1,6 +1,7 @@
 const caches = require('./caches')
 const commands = require('./commands')
 const { GRAMMAR_SCOPES } = require('./constants')
+const optInManager = require('./optInManager')
 const reportError = require('./reportError')
 
 const commandDisposable = atom.commands.add('atom-workspace', commands)
@@ -11,9 +12,28 @@ let lint = (...args) => {
   return loaded(...args)
 }
 
+exports.config = {
+  enabledProjects: {
+    title: 'Enable',
+    description: 'Control whether linting should be enabled manually, for each project, or is enabled for all projects.',
+    type: 'number',
+    default: optInManager.SOME,
+    enum: [
+      {value: optInManager.NONE, description: 'Reset existing permissions'},
+      {value: optInManager.SOME, description: 'Decide for each project'},
+      {value: optInManager.ALL, description: 'Enable for all projects'}
+    ]
+  }
+}
+
+exports.activate = state => {
+  optInManager.activate(state && state.optIn)
+}
+
 exports.deactivate = () => {
   caches.clearAll()
   commandDisposable.dispose()
+  optInManager.deactivate()
 }
 
 exports.provideLinter = () => ({
@@ -25,3 +45,5 @@ exports.provideLinter = () => ({
     return lint(textEditor, reportError)
   }
 })
+
+exports.serialize = () => ({ optIn: optInManager.serialize() })

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "scripts": {
     "lint": "standard",
-    "test": "mocha",
+    "test": "mocha test/**/*.spec.js",
     "posttest": "standard",
     "coverage": "nyc npm test"
   },

--- a/test/lib/linting.spec.js
+++ b/test/lib/linting.spec.js
@@ -120,24 +120,24 @@ describe('lib/linting', () => {
       return expect(linting.fix(textEditor), 'to be fulfilled')
         .then(output => expect(output, 'to equal', 'fixed'))
     })
-
-    it('should return null if the file is ignored', () => {
-      stub = () => Promise.reject(new Error('Should never be called'))
-      const filePath = path.resolve(__dirname, '..', 'fixtures', 'scopedLinter', 'world')
-      const textEditor = textEditorFactory({
-        source: 'var foo = "bar"',
-        path: filePath
-      })
-      return expect(linting.fix(textEditor), 'to be fulfilled')
-        .then(output => expect(output, 'to be null'))
-    })
   })
 
-  for (const { method, emptiness } of [
-    { method: 'fix', emptiness: 'null' },
-    { method: 'lint', emptiness: 'empty' }
+  for (const { method, emptiness, returnDescription } of [
+    { method: 'fix', emptiness: 'null', returnDescription: 'null' },
+    { method: 'lint', emptiness: 'empty', returnDescription: 'an empty array' }
   ]) {
     describe(`${method}()`, () => {
+      it(`should return ${returnDescription} if the file is ignored`, () => {
+        stub = () => Promise.reject(new Error('Should never be called'))
+        const filePath = path.resolve(__dirname, '..', 'fixtures', 'scopedLinter', 'world')
+        const textEditor = textEditorFactory({
+          source: 'var foo = "bar"',
+          path: filePath
+        })
+        return expect(linting[method](textEditor), 'to be fulfilled')
+          .then(output => expect(output, `to be ${emptiness}`))
+      })
+
       describe('error handling', () => {
         let currentError
         const stubbedOptions = proxyquire('../../lib/linting', {

--- a/test/lib/optInManager.spec.js
+++ b/test/lib/optInManager.spec.js
@@ -1,0 +1,153 @@
+/* global beforeEach, after, describe, it */
+const {createHash} = require('crypto')
+const expect = require('unexpected').clone()
+
+const optInManager = require('../../lib/optInManager')
+
+describe('optInManager', () => {
+  beforeEach(() => {
+    atom.config._callbacks = new Map()
+    atom.config._map = new Map([['linter-js-standard-engine.enabledProjects', optInManager.SOME]])
+    atom.notifications._enableLinters = []
+    optInManager.activate()
+  })
+
+  after(() => {
+    atom.notifications._enableLinters = null
+    atom.config._map = new Map()
+    atom.config._callbacks = new Map()
+  })
+
+  describe('checkPermission()', () => {
+    it('shows a notification', () => {
+      optInManager.checkPermission()
+      expect(atom.notifications._enableLinters, 'not to be empty')
+    })
+
+    it('returns false if notification is dismissed', () => {
+      const promise = optInManager.checkPermission()
+      atom.notifications._enableLinters[0]._dismiss()
+      return expect(promise, 'to be fulfilled with', false)
+    })
+
+    it('returns true if button to allow project is clicked', () => {
+      const promise = optInManager.checkPermission()
+      atom.notifications._enableLinters[0].options.buttons[0].onDidClick()
+      return expect(promise, 'to be fulfilled with', true)
+    })
+
+    it('returns true if button to allow all projects is clicked', () => {
+      const promise = optInManager.checkPermission()
+      atom.notifications._enableLinters[0].options.buttons[1].onDidClick()
+      return expect(promise, 'to be fulfilled with', true)
+    })
+
+    it('returns true if all projects are allowed', () => {
+      atom.config.set('linter-js-standard-engine.enabledProjects', optInManager.ALL)
+      optInManager.activate()
+      return expect(optInManager.checkPermission(), 'to be fulfilled with', true)
+    })
+
+    it('updates config if all projects are allowed', () => {
+      optInManager.checkPermission()
+      atom.notifications._enableLinters[0].options.buttons[1].onDidClick()
+      expect(atom.config._map.get('linter-js-standard-engine.enabledProjects'), 'to be', optInManager.ALL)
+    })
+
+    it('dismisses notification if the first button is clicked', () => {
+      optInManager.checkPermission()
+
+      let dismissed = false
+      atom.notifications._enableLinters[0]._callbacks.add(() => {
+        dismissed = true
+      })
+      atom.notifications._enableLinters[0].options.buttons[0].onDidClick()
+      expect(dismissed, 'to be', true)
+    })
+
+    it('dismisses notification if the second button is clicked', () => {
+      optInManager.checkPermission()
+
+      let dismissed = false
+      atom.notifications._enableLinters[0]._callbacks.add(() => {
+        dismissed = true
+      })
+      atom.notifications._enableLinters[0].options.buttons[1].onDidClick()
+      expect(dismissed, 'to be', true)
+    })
+
+    it('caches results', () => {
+      const promise = optInManager.checkPermission('foo', 'bar')
+      expect(promise, 'to be', optInManager.checkPermission('foo', 'bar'))
+      expect(promise, 'not to be', optInManager.checkPermission('foo', 'BAZ'))
+    })
+
+    it('tracks allowed linters and projects', () => {
+      optInManager.checkPermission('foo', 'bar')
+      atom.notifications._enableLinters[0].options.buttons[0].onDidClick()
+      const {allowed} = optInManager.serialize()
+      expect(allowed, 'not to be empty')
+    })
+  })
+
+  describe('activate()', () => {
+    it('subscribes to config changes', () => {
+      expect(atom.config._callbacks.get('linter-js-standard-engine.enabledProjects').size, 'to be', 1)
+    })
+
+    describe('after config changes to NONE', () => {
+      it('resets to SOME', () => {
+        atom.config._map.delete('linter-js-standard-engine.enabledProjects')
+        for (const cb of atom.config._callbacks.get('linter-js-standard-engine.enabledProjects')) {
+          cb({ newValue: optInManager.NONE })
+        }
+        expect(atom.config._map.get('linter-js-standard-engine.enabledProjects'), 'to be', optInManager.SOME)
+      })
+    })
+
+    describe('after config changes to ALL', () => {
+      describe('checkPermission()', () => {
+        it('always returns true, without prompting', () => {
+          for (const cb of atom.config._callbacks.get('linter-js-standard-engine.enabledProjects')) {
+            cb({ newValue: optInManager.ALL })
+          }
+
+          expect(optInManager.checkPermission(), 'to be fulfilled with', true)
+          expect(atom.notifications._enableLinters, 'to be empty')
+        })
+      })
+    })
+
+    describe('deserializes state, which is used by checkPermission()', () => {
+      it('always true for an allowed linter & project, without prompting', () => {
+        const seed = Buffer.from('decafbad', 'hex')
+        const serialized = {
+          seed: seed.toString('base64'),
+          allowed: [createHash('sha256').update(seed).update('foo\nbar').digest('base64')]
+        }
+        optInManager.activate(serialized)
+
+        expect(optInManager.checkPermission('foo', 'bar'), 'to be fulfilled with', true)
+        expect(atom.notifications._enableLinters, 'to be empty')
+      })
+    })
+  })
+
+  describe('deactivate()', () => {
+    it('disposes the config change subscription', () => {
+      optInManager.deactivate()
+      expect(atom.config._callbacks.get('linter-js-standard-engine.enabledProjects').size, 'to be', 0)
+    })
+  })
+
+  describe('serialize()', () => {
+    const seed = Buffer.from('decafbad', 'hex')
+    const serialized = {
+      seed: seed.toString('base64'),
+      allowed: [createHash('sha256').update(seed).update('foo\nbar').digest('base64')]
+    }
+    optInManager.activate(serialized)
+
+    expect(optInManager.serialize(), 'to equal', serialized)
+  })
+})

--- a/test/lib/register.spec.js
+++ b/test/lib/register.spec.js
@@ -7,7 +7,8 @@ const path = require('path')
 const expect = require('unexpected').clone()
 const proxyquire = require('proxyquire').noPreserveCache()
 
-const plugin = require('../../lib/register')
+const plugin = proxyquire('../../lib/register', {})
+
 const textEditorFactory = require('../util/textEditorFactory')
 
 const linter = plugin.provideLinter()
@@ -21,6 +22,8 @@ expect.addAssertion('to be a valid lint report', (expect, subject) => expect(sub
 }))
 
 describe('linter-js-standard-engine', () => {
+  plugin.activate()
+
   it('should be able to lint a test file', () => {
     const textEditor = textEditorFactory('var foo = "bar"')
     return expect(lint(textEditor), 'to be fulfilled').then(data => expect(data, 'to be a valid lint report'))
@@ -55,6 +58,7 @@ describe('linter-js-standard-engine', () => {
         }
       }
     })
+    plugin.activate()
 
     expect(cleared, 'to be false')
     plugin.deactivate()
@@ -118,5 +122,31 @@ describe('linter-js-standard-engine', () => {
 
     lint(textEditorFactory(''))
     expect(actual, 'to be', require('../../lib/reportError'))
+  })
+
+  it('should serialize the opt-in manager', () => {
+    const expected = { foo: 'bar' }
+    const { serialize } = proxyquire('../../lib/register', {
+      './optInManager': {
+        serialize: () => expected
+      }
+    })
+
+    expect(serialize(), 'to equal', { optIn: expected })
+  })
+
+  it('should activate the opt-in manager with serialized state', () => {
+    const expected = { foo: 'bar' }
+    let actual
+    const { activate } = proxyquire('../../lib/register', {
+      './optInManager': {
+        activate (state) {
+          actual = state
+        }
+      }
+    })
+
+    activate({ optIn: expected })
+    expect(actual, 'to be', expected)
   })
 })

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,3 @@
 --recursive
 --reporter spec
 --require test/util/atomHelper
-test/**/*.spec.js


### PR DESCRIPTION
Fixes #41.

~Still needs tests and documentation.~

@gustavnikolaj if you have a chance (no rush!) please give this a go. I hope it strikes the right balance between not asking all the time yet still allowing users to opt in on a per-project or global basis. Toggle the "Reset permissions" in the package settings to reset the permissions.