### PR TITLE
add support for new sync lintText method in std-engine 6

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -41,7 +41,12 @@ process.on('message', ({ filename, fix, id, text }) => {
      * handle the older versions of standard-engine based linters. We can
      * remove it in a later major version, if it becomes a liability.
      */
-    const returnValue = linter.lintText(text, { filename, fix }, (err, { results } = {}) => {
+    let returnValue
+    returnValue = linter.lintText(text, { filename, fix }, (err, { results } = {}) => {
+      if (returnValue) {
+        return
+      }
+
       if (err) {
         process.send({
           error: cleanYamlObject(err),

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -36,7 +36,12 @@ process.on('message', ({ filename, fix, id, text }) => {
   }
 
   try {
-    linter.lintText(text, { filename, fix }, (err, { results } = {}) => {
+    /* In standard-engine <6.0.0 the linter.lintText was async, but from
+     * version 6.0.0 it changed to be sync. This callback is left in here to
+     * handle the older versions of standard-engine based linters. We can
+     * remove it in a later major version, if it becomes a liability.
+     */
+    const returnValue = linter.lintText(text, { filename, fix }, (err, { results } = {}) => {
       if (err) {
         process.send({
           error: cleanYamlObject(err),
@@ -49,6 +54,14 @@ process.on('message', ({ filename, fix, id, text }) => {
         })
       }
     })
+
+    if (returnValue) {
+      const { results } = returnValue
+      return process.send({
+        id,
+        results
+      })
+    }
   } catch (err) {
     process.send({
       error: cleanYamlObject(err),

--- a/test/fixtures/stubForWorker/errOnLint-sync.js
+++ b/test/fixtures/stubForWorker/errOnLint-sync.js
@@ -1,0 +1,3 @@
+exports.lintText = (source, opts) => {
+  throw new Error('err when linting')
+}

--- a/test/fixtures/stubForWorker/lintText-async.js
+++ b/test/fixtures/stubForWorker/lintText-async.js
@@ -1,0 +1,3 @@
+exports.lintText = (source, opts, cb) => {
+  cb(null, { results: [] })
+}

--- a/test/fixtures/stubForWorker/lintText-faulty.js
+++ b/test/fixtures/stubForWorker/lintText-faulty.js
@@ -1,4 +1,4 @@
 exports.lintText = (source, opts, cb) => {
-  setImmediate(() => cb(null, { results: [] }))
-  return { results: [] }
+  setImmediate(() => cb(null, { results: [ { callback: true } ] }))
+  return { results: [ { callback: false } ] }
 }

--- a/test/fixtures/stubForWorker/lintText-faulty.js
+++ b/test/fixtures/stubForWorker/lintText-faulty.js
@@ -1,0 +1,4 @@
+exports.lintText = (source, opts, cb) => {
+  setImmediate(() => cb(null, { results: [] }))
+  return { results: [] }
+}

--- a/test/fixtures/stubForWorker/lintText-sync.js
+++ b/test/fixtures/stubForWorker/lintText-sync.js
@@ -1,0 +1,3 @@
+exports.lintText = (source, opts) => {
+  return { results: [] }
+}

--- a/test/lib/worker.spec.js
+++ b/test/lib/worker.spec.js
@@ -199,7 +199,7 @@ describe('handle both async and sync lintText', () => {
     child.send({ id: 1, source: '' })
 
     return expect(promise, 'when fulfilled to equal', [
-      { id: 1, results: [] }
+      { id: 1, results: [ { callback: false } ] }
     ])
   })
 })

--- a/test/lib/worker.spec.js
+++ b/test/lib/worker.spec.js
@@ -177,4 +177,29 @@ describe('handle both async and sync lintText', () => {
       })
     })
   })
+  it('should protect against faulty standard-engine implementations', () => {
+    /* This test is supposed to guard verify that a faulty lintText implementation
+     * is not going to trigger two messages. It is a bit brittle, as I have to rely
+     * on a timeout being queued after receiving the first message, to check that
+     * no other messages are received at a later point.
+     */
+    const child = childProcess.fork(workerPath, [require.resolve('../fixtures/stubForWorker/lintText-faulty')])
+    let calls = []
+    let calledOnce = false
+    const promise = new Promise(resolve => {
+      child.on('message', m => {
+        calls.push(m)
+        if (!calledOnce) {
+          calledOnce = true
+          setTimeout(() => resolve(calls), 100)
+        }
+      })
+    })
+
+    child.send({ id: 1, source: '' })
+
+    return expect(promise, 'when fulfilled to equal', [
+      { id: 1, results: [] }
+    ])
+  })
 })

--- a/test/lib/worker.spec.js
+++ b/test/lib/worker.spec.js
@@ -113,3 +113,68 @@ describe('lib/worker', () => {
     })
   })
 })
+
+describe('handle both async and sync lintText', () => {
+  describe('sync', () => {
+    it('should get a lint result', () => {
+      const child = childProcess.fork(workerPath, [require.resolve('../fixtures/stubForWorker/lintText-sync')])
+      const promise = new Promise(resolve => {
+        child.on('message', m => resolve(m))
+      })
+
+      child.send({ id: 1, source: '' })
+
+      return expect(promise, 'when fulfilled', 'to satisfy', {
+        id: 1,
+        results: []
+      })
+    })
+    it('should get a lint error', () => {
+      const child = childProcess.fork(workerPath, [require.resolve('../fixtures/stubForWorker/errOnLint-sync')])
+      const promise = new Promise(resolve => {
+        child.on('message', m => resolve(m))
+      })
+
+      child.send({ id: 1, source: '' })
+
+      return expect(promise, 'when fulfilled', 'to satisfy', {
+        id: 1,
+        error: {
+          name: 'Error',
+          message: 'err when linting'
+        }
+      })
+    })
+  })
+  describe('async', () => {
+    it('should get a lint result', () => {
+      const child = childProcess.fork(workerPath, [require.resolve('../fixtures/stubForWorker/lintText-async')])
+      const promise = new Promise(resolve => {
+        child.on('message', m => resolve(m))
+      })
+
+      child.send({ id: 1, source: '' })
+
+      return expect(promise, 'when fulfilled', 'to satisfy', {
+        id: 1,
+        results: []
+      })
+    })
+    it('should get a lint error', () => {
+      const child = childProcess.fork(workerPath, [require.resolve('../fixtures/stubForWorker/errOnLint')])
+      const promise = new Promise(resolve => {
+        child.on('message', m => resolve(m))
+      })
+
+      child.send({ id: 1, source: '' })
+
+      return expect(promise, 'when fulfilled', 'to satisfy', {
+        id: 1,
+        error: {
+          name: 'Error',
+          message: 'err when linting'
+        }
+      })
+    })
+  })
+})


### PR DESCRIPTION
Fixes #45 

I have tested it locally against version `3.0.0` of the `onelint`-package running `standard-engine@6.0.0` and a version of `standard` running `standard-engine@^5`.