### PR TITLE
Support lintTextSync()

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -36,35 +36,19 @@ process.on('message', ({ filename, fix, id, text }) => {
   }
 
   try {
-    /* In standard-engine <6.0.0 the linter.lintText was async, but from
-     * version 6.0.0 it changed to be sync. This callback is left in here to
-     * handle the older versions of standard-engine based linters. We can
-     * remove it in a later major version, if it becomes a liability.
-     */
-    let returnValue
-    returnValue = linter.lintText(text, { filename, fix }, (err, { results } = {}) => {
-      if (returnValue) {
-        return
-      }
-
-      if (err) {
-        process.send({
-          error: cleanYamlObject(err),
-          id
-        })
-      } else {
-        process.send({
-          id,
-          results
-        })
-      }
-    })
-
-    if (returnValue) {
-      const { results } = returnValue
-      return process.send({
-        id,
-        results
+    if (linter.lintTextSync) {
+      const { results } = linter.lintTextSync(text, { filename, fix })
+      process.send({ id, results })
+    } else {
+      linter.lintText(text, { filename, fix }, (err, { results } = {}) => {
+        if (err) {
+          process.send({
+            error: cleanYamlObject(err),
+            id
+          })
+        } else {
+          process.send({ id, results })
+        }
       })
     }
   } catch (err) {

--- a/test/fixtures/stubForWorker/errOnLint-sync.js
+++ b/test/fixtures/stubForWorker/errOnLint-sync.js
@@ -1,3 +1,3 @@
-exports.lintText = (source, opts) => {
+exports.lintTextSync = (source, opts) => {
   throw new Error('err when linting')
 }

--- a/test/fixtures/stubForWorker/lintText-faulty.js
+++ b/test/fixtures/stubForWorker/lintText-faulty.js
@@ -1,4 +1,0 @@
-exports.lintText = (source, opts, cb) => {
-  setImmediate(() => cb(null, { results: [ { callback: true } ] }))
-  return { results: [ { callback: false } ] }
-}

--- a/test/fixtures/stubForWorker/lintText-sync.js
+++ b/test/fixtures/stubForWorker/lintText-sync.js
@@ -1,3 +1,3 @@
-exports.lintText = (source, opts) => {
+exports.lintTextSync = (source, opts) => {
   return { results: [] }
 }

--- a/test/lib/worker.spec.js
+++ b/test/lib/worker.spec.js
@@ -177,29 +177,4 @@ describe('handle both async and sync lintText', () => {
       })
     })
   })
-  it('should protect against faulty standard-engine implementations', () => {
-    /* This test is supposed to guard verify that a faulty lintText implementation
-     * is not going to trigger two messages. It is a bit brittle, as I have to rely
-     * on a timeout being queued after receiving the first message, to check that
-     * no other messages are received at a later point.
-     */
-    const child = childProcess.fork(workerPath, [require.resolve('../fixtures/stubForWorker/lintText-faulty')])
-    let calls = []
-    let calledOnce = false
-    const promise = new Promise(resolve => {
-      child.on('message', m => {
-        calls.push(m)
-        if (!calledOnce) {
-          calledOnce = true
-          setTimeout(() => resolve(calls), 100)
-        }
-      })
-    })
-
-    child.send({ id: 1, source: '' })
-
-    return expect(promise, 'when fulfilled to equal', [
-      { id: 1, results: [ { callback: false } ] }
-    ])
-  })
 })


### PR DESCRIPTION
standard-engine@7 restores the asynchronous lintText() of
standard-engine@5, and adds a new lintTextSync() method.

This commit uses either lintTextSync() or the asynchronous lintText().
Support for the standard-engine@6 behavior is removed. Presumably it
wasn't widely deployed, and it's a whole bunch of complex logic to
maintain.

See https://github.com/Flet/standard-engine/pull/159.