### PR TITLE
Support ignore in package.json

### DIFF
--- a/lib/linting.js
+++ b/lib/linting.js
@@ -27,6 +27,12 @@ class InvalidReportError extends ExtendableError {
   }
 }
 
+const fileIsIgnored = (filePath, projectRoot, ignoreGlobs) => {
+  const relativePath = relative(projectRoot, filePath)
+  console.log('relativePath', relativePath, 'in', projectRoot)
+  return ignoreGlobs.some(pattern => minimatch(relativePath, pattern, {debug: true, dot: true}))
+}
+
 function getReport (textEditor, fix) {
   const { scopeName } = textEditor.getGrammar()
   if (!GRAMMAR_SCOPES.includes(scopeName)) return Promise.resolve(null)
@@ -37,9 +43,7 @@ function getReport (textEditor, fix) {
 
   return findOptions(filePath)
     .then(({ linterName, projectRoot, ignoreGlobs }) => {
-      const relativePath = relative(projectRoot, filePath)
-      const fileIsIgnored = ignoreGlobs.some(pattern => minimatch(relativePath, pattern))
-      if (fileIsIgnored) return null
+      if (fileIsIgnored(filePath, projectRoot, ignoreGlobs)) return null
 
       return checkPermission(linterName, projectRoot)
         .then(allowed => {
@@ -103,5 +107,6 @@ function lint (textEditor, reportError) {
     })
 }
 
+exports.fileIsIgnored = fileIsIgnored
 exports.fix = fix
 exports.lint = lint

--- a/test/fixtures/misc/package.json
+++ b/test/fixtures/misc/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "misc",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "lint": "standard | snazzy",
+    "test": "npm run lint --silent"
+  },
+  "devDependencies": {
+    "snazzy": "^7.0.0",
+    "standard": "^10.0.2"
+  },
+  "standard": {
+    "ignore": [
+      "should-not-be-linted"
+    ]
+  }
+}

--- a/test/fixtures/misc/should-be-linted/index.js
+++ b/test/fixtures/misc/should-be-linted/index.js
@@ -1,0 +1,3 @@
+var x = 10
+
+console.log(x)

--- a/test/fixtures/misc/should-not-be-linted/index.js
+++ b/test/fixtures/misc/should-not-be-linted/index.js
@@ -1,0 +1,5 @@
+// This fails standard, but it should be ignored
+
+var x = 10;
+
+console.log(x);


### PR DESCRIPTION
I don't know what we're doing wrong, but as the tests shows, `minimatch` is not behaving as we expect.

```
$ node
> var minimatch = require('minimatch')
undefined
> minimatch('foo', 'foo')
true
> minimatch('foo/bar.js', 'foo')
false
```

The `ignore` support in standard-engine comes from https://github.com/standard/deglob which depends on https://github.com/isaacs/node-glob which depends on minimatch, so it should be possible to figure it out :-)