### PR TITLE
Lint `javascript` grammar scope by default

### DIFF
--- a/lib/register.js
+++ b/lib/register.js
@@ -27,7 +27,7 @@ exports.config = {
     title: 'Scopes',
     description: 'Grammar scopes for which linting is enabled. Reload window for changes to take effect.',
     type: 'array',
-    default: ['source.js', 'source.js.jsx'],
+    default: ['javascript', 'source.js', 'source.js.jsx'],
     items: {
       type: 'string'
     }

--- a/test/util/atomHelper.js
+++ b/test/util/atomHelper.js
@@ -36,7 +36,7 @@ if (typeof global.atom === 'undefined') {
       _map: new Map(),
 
       get (key) {
-        if (key === 'linter-js-standard-engine.grammarScopes') return ['source.js', 'source.js.jsx']
+        if (key === 'linter-js-standard-engine.grammarScopes') return ['javascript', 'source.js', 'source.js.jsx']
         return this._map.get(key)
       },
 


### PR DESCRIPTION
The `javascript` scope is used by Atom’s experimental [Tree-sitter](https://github.com/tree-sitter/tree-sitter) parsing system.

Fixes #58. See also https://github.com/AtomLinter/linter-eslint/pull/1115 and https://github.com/ricardofbarros/linter-js-standard/commit/30096674ed7fcfb58bf20b1792333381e9857c9a.